### PR TITLE
Adds the ability to pass a CultureInfo into the BindXXX Methods

### DIFF
--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -150,7 +150,7 @@ type HttpContext with
                         | "application/xml"                   -> this.BindXmlAsync<'T>()
                         | "application/x-www-form-urlencoded" -> this.BindFormAsync<'T>(?cultureInfo = cultureInfo)
                         | _ -> failwithf "Cannot bind model from Content-Type '%s'" original.Value
-            else return this.BindQueryString<'T>()
+            else return this.BindQueryString<'T>(?cultureInfo = cultureInfo)
         }
 
     /// ---------------------------

--- a/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
+++ b/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
@@ -1,6 +1,7 @@
 module Giraffe.HttpContextExtensionsTests
 
 open System
+open System.Globalization
 open System.Collections.Generic
 open System.IO
 open System.Text
@@ -188,6 +189,35 @@ let ``BindQueryString test`` () =
     ctx.Response.Body <- new MemoryStream()
 
     let expected = "Name: John Doe, IsVip: true, BirthDate: 1990-04-20, Balance: 150000.50, LoyaltyPoints: 137"
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
+let ``BindQueryString culture specific test`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let queryHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            let model = ctx.BindQueryString<Customer>(CultureInfo.CreateSpecificCulture("en-GB"))
+            text (model.ToString()) next ctx
+
+    let app = GET >=> route "/query" >=> queryHandler
+
+    let queryStr = "?Name=John%20Doe&IsVip=true&BirthDate=12/04/1998 12:34:56&Balance=150000.5&LoyaltyPoints=137"
+    let query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery queryStr
+    let asdf = QueryCollection(query) :> IQueryCollection
+    ctx.Request.Query.ReturnsForAnyArgs(QueryCollection(query) :> IQueryCollection) |> ignore
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/query")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "Name: John Doe, IsVip: true, BirthDate: 1998-04-12, Balance: 150000.50, LoyaltyPoints: 137"
 
     task {
         let! result = app (Some >> Task.FromResult) ctx
@@ -392,6 +422,49 @@ let ``BindModelAsync with FORM content returns correct result`` () =
     }
 
 [<Fact>]
+let ``BindModelAsync with FORM content culture aware returns correct result`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let autoHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let! model = ctx.BindModelAsync<Customer>(CultureInfo.CreateSpecificCulture("en-GB"))
+                return! text (model.ToString()) next ctx
+            }
+
+    let app = route "/auto" >=> autoHandler
+
+    let contentType = "application/x-www-form-urlencoded"
+    let headers = HeaderDictionary()
+    headers.Add("Content-Type", StringValues(contentType))
+    ctx.Request.HasFormContentType.ReturnsForAnyArgs true |> ignore
+    let form =
+        dict [
+            "Name", StringValues("John Doe")
+            "IsVip", StringValues("true")
+            "BirthDate", StringValues("04/01/2015 05:45:00")
+            "Balance", StringValues("150000.5")
+            "LoyaltyPoints", StringValues("137")
+        ] |> Dictionary
+    let taskColl = System.Threading.Tasks.Task.FromResult(FormCollection(form) :> IFormCollection)
+    ctx.Request.ReadFormAsync().ReturnsForAnyArgs(taskColl) |> ignore
+    ctx.Request.ContentType.ReturnsForAnyArgs contentType |> ignore
+    ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/auto")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "Name: John Doe, IsVip: true, BirthDate: 2015-01-04, Balance: 150000.50, LoyaltyPoints: 137"
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
 let ``BindModelAsync with JSON content and a specific charset returns correct result`` () =
     let ctx = Substitute.For<HttpContext>()
 
@@ -462,6 +535,38 @@ let ``BindModelAsync during HTTP GET request with query string returns correct r
         | None     -> assertFailf "Result was expected to be %s" expected
         | Some ctx -> Assert.Equal(expected, getBody ctx)
     }
+
+[<Fact>]
+let ``BindModelAsync during HTTP GET request with query string culture aware returns correct result`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let autoHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let! model = ctx.BindModelAsync<Customer>(CultureInfo.CreateSpecificCulture("en-GB"))
+                return! text (model.ToString()) next ctx
+            }
+
+    let app = route "/auto" >=> autoHandler
+
+    let queryStr = "?Name=John%20Doe&IsVip=true&BirthDate=15/06/2013 06:00:00&Balance=150000.5&LoyaltyPoints=137"
+    let query = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery queryStr
+    let asdf = QueryCollection(query) :> IQueryCollection
+    ctx.Request.Query.ReturnsForAnyArgs(QueryCollection(query) :> IQueryCollection) |> ignore
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/auto")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "Name: John Doe, IsVip: true, BirthDate: 2013-06-15, Balance: 150000.50, LoyaltyPoints: 137"
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None     -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
 
 [<Fact>]
 let ``TryGetRequestHeader during HTTP GET request with returns correct result`` () =


### PR DESCRIPTION
This allows users to pass a `CultureInfo` into the BindXXX methods, which allows users to control the de-serialization of the strings. This is particularly useful for DateTimes, for example MM/dd/yyyy vs dd/MM/yyy

There are no API changes and this is opt in using optional parameters. 

      let entraderTradeHandler : HttpHandler = 
               fun (next:HttpFunc) (ctx:HttpContext) ->  
                  task {
                    let config = ctx.GetService<StodDataService.Configuration>()
                    let query = ctx.BindQueryString<DataServices.EnTrader.TradeQuery>(CultureInfo.CurrentCulture)
                    use client = DataServices.EnTrader.createService config.EnTraderUrl config.EnTraderUsername config.EnTraderPassword
                    let! data = DataServices.EnTrader.getTrades query client |> Async.StartAsTask
                    match data with 
                    | Ok data -> 
                          do setData data ctx
                          return! next ctx
                    | Error e -> 
                         return! (setStatusCode 500 >=> text e) next ctx
               }
  