### PR TITLE
added parseValidate

### DIFF
--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -82,16 +82,6 @@ let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreC
     with
     | _ -> None
 
-let private matchDict = 
-    dict [
-        'b', typeof<bool>           // bool
-        'c', typeof<char>           // char
-        's', typeof<string>         // string
-        'i', typeof<int32>          // int
-        'd', typeof<int64>          // int64
-        'f', typeof<float>          // float
-        'O', typeof<System.Guid>    // guid
-]
 let parseValidate (format : PrintfFormat<_,_,_,_, 'T>) =
 
     let t = typeof<'T>
@@ -101,12 +91,22 @@ let parseValidate (format : PrintfFormat<_,_,_,_, 'T>) =
     let mutable matches = 0
     for i in 0 .. path.Length - 1 do
         let mchar = path.[i]
-        if matchNext then
-            match matchDict.TryGetValue mchar with
-            | true , v -> 
-                parseChars <- (mchar,v) :: parseChars
-                matches <- matches + 1                            
-            | false, _ -> ()
+        if matchNext then    
+            match mchar with
+            | 'b' -> typeof<bool>           // bool
+            | 'c' -> typeof<char>           // char
+            | 's' -> typeof<string>         // string
+            | 'i' -> typeof<int32>          // int
+            | 'd' -> typeof<int64>          // int64
+            | 'f' -> typeof<float>          // float
+            | 'O' -> typeof<System.Guid>    // guid
+            | _   -> null
+            |> function
+            | null -> ()
+            | x -> 
+                parseChars <- (mchar,x) :: parseChars
+                matches <- matches + 1 
+
             matchNext <- false
         else
             if mchar = '%' then matchNext <- true

--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -82,30 +82,64 @@ let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreC
     with
     | _ -> None
 
-let parseValidate (format : PrintfFormat<_,_,_,_, 'T>) =
+let validateFormat (format : PrintfFormat<_,_,_,_, 'T>) =
+
+    let mapping = [
+        'b' , typeof<bool>           // bool
+        'c' , typeof<char>           // char
+        's' , typeof<string>         // string
+        'i' , typeof<int32>          // int
+        'd' , typeof<int64>          // int64
+        'f' , typeof<float>          // float
+        'O' , typeof<System.Guid>    // guid
+    ]
+
+    let tuplePrint pos last name =
+        let mutable result = "("
+        for i in 0 .. last do
+            if i = pos 
+            then result <- result + name
+            else result <- result + "_"             
+            if i <> last then result <- result + ","
+        result + ")"
+
+    let posPrint =
+        function
+        | 1 -> "1st"
+        | 2 -> "2nd"
+        | 3 -> "3rd"
+        | x -> x.ToString() + "th"
 
     let t = typeof<'T>
     let path = format.Value
     let mutable parseChars = []
     let mutable matchNext = false
     let mutable matches = 0
+
+    let rec charTypeMatch ls mchar =
+        match ls with
+        | [] -> ()
+        | (tchar,x) :: xs -> 
+            if tchar = mchar then
+                parseChars <- (mchar,x) :: parseChars
+                matches <- matches + 1
+            else
+                charTypeMatch xs mchar
+
+    let rec typeCharMatch ls (xtype:System.Type) =
+        match ls with
+        | [] -> sprintf "%s has no associated format char parameter" xtype.Name
+        | (tchar,x) :: xs -> 
+            if xtype = x then
+                sprintf "%s uses format char '%%%c'" xtype.Name tchar
+            else
+                typeCharMatch xs xtype
+
+
     for i in 0 .. path.Length - 1 do
         let mchar = path.[i]
         if matchNext then    
-            match mchar with
-            | 'b' -> typeof<bool>           // bool
-            | 'c' -> typeof<char>           // char
-            | 's' -> typeof<string>         // string
-            | 'i' -> typeof<int32>          // int
-            | 'd' -> typeof<int64>          // int64
-            | 'f' -> typeof<float>          // float
-            | 'O' -> typeof<System.Guid>    // guid
-            | _   -> null
-            |> function
-            | null -> ()
-            | x -> 
-                parseChars <- (mchar,x) :: parseChars
-                matches <- matches + 1 
+            charTypeMatch mapping mchar
 
             matchNext <- false
         else
@@ -113,24 +147,30 @@ let parseValidate (format : PrintfFormat<_,_,_,_, 'T>) =
 
     if FSharpType.IsTuple(t) then 
         let types = FSharpType.GetTupleElements(t)
-        if types.Length <> matches then failwithf "Error reading match expression: tuple of %i vs chars of %i" types.Length matches
+        if types.Length <> matches then failwithf "Format string error: Number of parameters (%i) does not match number of tuple variables (%i)." types.Length matches
         
         let rec check(ls,pos) =
             match ls, pos with
             | [] , -1 -> ()
             | (mchar,ct) :: xs , i -> 
-                if ct <> types.[i] then 
-                    failwithf "Error with routef parse types: '%%%c' for parse type %s does not match expected type %s at tuple param:%i" mchar ct.FullName types.[i].FullName (i + 1)
+                if ct <> types.[i] then
+                    let hdlFmt = tuplePrint i (types.Length - 1) types.[i].Name
+                    let expFmt = tuplePrint i (types.Length - 1)  ct.Name
+                    let guidance = typeCharMatch mapping types.[i]
+
+                    failwithf "Format string error: routef '%s' has type '%s' but handler expects '%s', mismatch on %s parameter '%%%c', %s." path expFmt hdlFmt (posPrint (i + 1)) mchar guidance   
                 else
                     check(xs,i - 1)
-            | x , y -> failwithf "Unknown parse validation error: %A [%i]" x y                
+            | x , y -> failwithf "Format string error: Unkown validation error: %A [%i]." x y                
 
         check( parseChars , types.Length - 1)                                        
 
     else
-        if matches <> 1 then failwithf "Error reading match expression: %i match chars found when expecting one " matches
+        if matches <> 1 then failwithf "Format string error: Number of parameters (%i) does not match single variable." matches
         match parseChars with
         | [(mchar,ct)] -> 
-            if ct <> t then failwithf "Error with routef parse type: '%%%c' for parse type %s does not match expected type %s" mchar ct.FullName t.FullName
-        | x -> failwithf "Unknown parse validation error: %A" x 
+            if ct <> t then 
+                let guidance = typeCharMatch mapping t
+                failwithf "Format string error: routef '%s' has type '%s' but handler expects '%s', mismatch on parameter '%%%c', %s." path ct.Name t.Name mchar guidance
+        | x -> failwithf "Format string error: Unkown validation error: %A." x 
 

--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -82,7 +82,7 @@ let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreC
     with
     | _ -> None
 
-let matchDict = 
+let private matchDict = 
     dict [
         'b', typeof<bool>           // bool
         'c', typeof<char>           // char

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -205,6 +205,7 @@ let route (path : string) : HttpHandler =
 /// %d -> int64
 /// %f -> float/double
 let routef (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
+    parseValidate path
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) false
         |> function

--- a/src/Giraffe/HttpHandlers.fs
+++ b/src/Giraffe/HttpHandlers.fs
@@ -205,7 +205,7 @@ let route (path : string) : HttpHandler =
 /// %d -> int64
 /// %f -> float/double
 let routef (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler) : HttpHandler =
-    parseValidate path
+    validateFormat path
     fun (next : HttpFunc) (ctx : HttpContext) ->
         tryMatchInput path (getPath ctx) false
         |> function

--- a/src/Giraffe/TokenRouter.fs
+++ b/src/Giraffe/TokenRouter.fs
@@ -280,7 +280,7 @@ let route (path:string) (fn:HttpHandler) (root:Node) =
 ///  * `parent` : `Node` - This parameter is applied by `router`, and is ommitted when building api such that function is partially applied fn
 ///  * `Node`
 let routef (path : PrintfFormat<_,_,_,_,'T>) (fn:'T -> HttpHandler) (root:Node) =
-    FormatExpressions.parseValidate path
+    FormatExpressions.validateFormat path
 
 // parsing route that iterates down nodes, parses, and then continues down further notes if needed
     let last = path.Value.Length - 1

--- a/src/Giraffe/TokenRouter.fs
+++ b/src/Giraffe/TokenRouter.fs
@@ -279,7 +279,9 @@ let route (path:string) (fn:HttpHandler) (root:Node) =
 ///**Output Type**
 ///  * `parent` : `Node` - This parameter is applied by `router`, and is ommitted when building api such that function is partially applied fn
 ///  * `Node`
-let routef (path : PrintfFormat<_,_,_,_,'T>) (fn:'T -> HttpHandler) (root:Node)=
+let routef (path : PrintfFormat<_,_,_,_,'T>) (fn:'T -> HttpHandler) (root:Node) =
+    FormatExpressions.parseValidate path
+
 // parsing route that iterates down nodes, parses, and then continues down further notes if needed
     let last = path.Value.Length - 1
 

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -12,6 +12,7 @@ open NSubstitute
 open Newtonsoft.Json
 open XmlViewEngine
 open Giraffe.Tests.Asserts
+open System
 
 // ---------------------------------
 // Helper functions
@@ -1500,3 +1501,16 @@ let ``GET "/api/{id}/" returns f40580b1-d55b-4fe2-b6fb-ca4f90749a9d``() =
             let body = getBody ctx
             Assert.Equal("f40580b1-d55b-4fe2-b6fb-ca4f90749a9d", body)
     }
+
+[<Fact>]
+let ``Test Parse Validation of %d as int`` () =
+    Assert.Throws( fun () -> 
+        GET >=> choose [
+            route   "/"       >=> text "Hello World"
+            route   "/foo"    >=> text "bar"
+            routef "/foo/%s/%d" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            setStatusCode 404 >=> text "Not found" ]
+        |> ignore
+    ) |> ignore
+
+    


### PR DESCRIPTION
To address an issue a number of users are having eg #184 , this validation will run at startup and warn the user of any invalid parse matching rather than it just failing to match at runtime for no apparent reason.

Test also added to cover common case of '%d' being expected to be a `int` rather than `int64`

@forki @isaacabraham