### PR TITLE
WIP: use dotnet-xunit to run *.Tests.fsproj.  Allows for running on mono.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,9 +32,15 @@ function Invoke-Cmd ($cmd)
     if ($LastExitCode -ne 0) { Write-Error "An error occured when executing '$cmd'."; return }
 }
 
-function Write-DotnetVersion
+
+function dotnet-version 
 {
     $dotnetVersion = Invoke-Cmd "dotnet --version"
+    return $dotnetVersion
+}
+function Write-DotnetVersion
+{
+    $dotnetVersion = dotnet-version 
     Write-Host ".NET Core runtime version: $dotnetVersion" -ForegroundColor Cyan
 }
 
@@ -42,6 +48,15 @@ function dotnet-restore ($project, $argv) { Invoke-Cmd "dotnet restore $project 
 function dotnet-build   ($project, $argv) { Invoke-Cmd "dotnet build $project $argv" }
 function dotnet-run     ($project, $argv) { Invoke-Cmd "dotnet run --project $project $argv" }
 function dotnet-test    ($project, $argv) { Invoke-Cmd "dotnet test $project $argv" }
+function dotnet-xunit    ($project, $argv) { 
+    # dotnet-tools must be run from the same directory as their proj file
+    Push-Location (Get-Item $project).Directory.FullName
+    # We need the dotnet version to pass to -fxversion
+    # see https://github.com/xunit/xunit/issues/1573 and https://github.com/dotnet/cli/issues/7901#issuecomment-352009367
+    $dotnetVersion = dotnet-version
+    Invoke-Cmd "dotnet xunit -fxversion $dotnetVersion $argv" 
+    Pop-Location
+}
 function dotnet-pack    ($project, $argv) { Invoke-Cmd "dotnet pack $project $argv" }
 
 function Test-Version ($project)
@@ -140,16 +155,10 @@ if (!$ExcludeTests.IsPresent -and !$Run.IsPresent)
 {
     Write-Host "Building and running tests..." -ForegroundColor Magenta
     $framework = Get-FrameworkArg $giraffeTests
-    # Currently dotnet test does not work for net461 on Linux/Mac
-    # See: https://github.com/Microsoft/vstest/issues/1318
-    if (!(Test-IsWindows)) {
-        Write-Warning "Running tests only for .NET Core build, because dotnet test does not support net4x tests on Linux/Mac at the moment (see: https://github.com/Microsoft/vstest/issues/1318)."
-        $fw = Get-NetCoreTargetFramework $giraffeTests
-        $framework = "-f $fw"
-    }
+
     dotnet-restore $giraffeTests
     dotnet-build   $giraffeTests $framework
-    dotnet-test    $giraffeTests $framework
+    dotnet-xunit $giraffeTests "" 
 }
 
 if (!$ExcludeSamples.IsPresent -and !$Run.IsPresent)

--- a/build.ps1
+++ b/build.ps1
@@ -176,7 +176,7 @@ if (!$ExcludeSamples.IsPresent -and !$Run.IsPresent)
 
     dotnet-restore $sampleAppTests
     dotnet-build   $sampleAppTests
-    dotnet-test    $sampleAppTests
+    dotnet-xunit   $sampleAppTests
 }
 
 if ($Run.IsPresent)

--- a/samples/SampleApp/SampleApp.Tests/SampleApp.Tests.fsproj
+++ b/samples/SampleApp/SampleApp.Tests/SampleApp.Tests.fsproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.*" />
     <PackageReference Include="xunit" Version="2.3.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.*" />
+
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -18,6 +18,9 @@
     <PackageReference Include="NSubstitute" Version="3.1.*" />
     <PackageReference Include="FsCheck" Version="3.0.0-*" />
     <PackageReference Include="FsCheck.Xunit" Version="3.0.0-*" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
+  
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #190. This is the 1st pass at using `dotnet-xunit` to run the tests for Giraffe.Tests.fsproj.  I'm not a powershell expert so please criticize.   

Due to some weird behavior in dotnet's cli tooling (https://github.com/xunit/xunit/issues/1573 and https://github.com/dotnet/cli/issues/7901#issuecomment-352009367) we have to pass the `-fxversion` to `dotnet-xunit`.  


```
dotnet xunit -fxversion 2.0.3
Detecting target frameworks in Giraffe.Tests.fsproj...
Building for framework net461...
  Giraffe -> /Users/username/Documents/GitHub/Giraffe/src/Giraffe/bin/Debug/net461/Giraffe.dll
  Giraffe.Tests -> /Users/username/Documents/GitHub/Giraffe/tests/Giraffe.Tests/bin/Debug/net461/Giraffe.Tests.dll
Running desktop CLR tests for framework net461...
xUnit.net Console Runner (64-bit Desktop .NET 4.0.30319.42000)
  Discovering: Giraffe.Tests
  Discovered:  Giraffe.Tests
  Starting:    Giraffe.Tests
  Finished:    Giraffe.Tests
=== TEST EXECUTION SUMMARY ===
   Giraffe.Tests  Total: 139, Errors: 0, Failed: 0, Skipped: 0, Time: 2.171s
Building for framework netcoreapp2.0...
  Giraffe -> /Users/username/Documents/GitHub/Giraffe/src/Giraffe/bin/Debug/netstandard2.0/Giraffe.dll
  Giraffe.Tests -> /Users/username/Documents/GitHub/Giraffe/tests/Giraffe.Tests/bin/Debug/netcoreapp2.0/Giraffe.Tests.dll
Running .NET Core 2.0.3 tests for framework netcoreapp2.0...
xUnit.net Console Runner (64-bit .NET Core 4.6.0.0)
  Discovering: Giraffe.Tests
  Discovered:  Giraffe.Tests
  Starting:    Giraffe.Tests
  Finished:    Giraffe.Tests
=== TEST EXECUTION SUMMARY ===
   Giraffe.Tests  Total: 139, Errors: 0, Failed: 0, Skipped: 0, Time: 1.137s
```

```
$ mono -V
Mono JIT compiler version 5.4.1.6 (2017-06/1f4613aa1ac Wed Oct 18 09:31:57 EDT 2017)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           normal
	SIGSEGV:       altstack
	Notification:  kqueue
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug
	LLVM:          yes(3.6.0svn-mono-master/8b1520c8aae)
	GC:            sgen (concurrent by default)
```