### PR TITLE
Fixes for handling nullables when binding query strings

### DIFF
--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -102,8 +102,12 @@ type HttpContext with
                     p.PropertyType.GetTypeInfo().IsGenericType &&
                     p.PropertyType.GetGenericTypeDefinition() = typedefof<Option<_>>
 
+                let isNullableType =
+                    p.PropertyType.GetTypeInfo().IsGenericType &&
+                    p.PropertyType.GetGenericTypeDefinition() = typedefof<Nullable<_>>
+
                 let propertyType =
-                    if isOptionType then
+                    if isOptionType || isNullableType then
                         p.PropertyType.GetGenericArguments().[0]
                     else
                         p.PropertyType

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -98,13 +98,13 @@ type HttpContext with
             | None            -> ()
             | Some queryValue ->
 
-                let isOptionType =
-                    p.PropertyType.GetTypeInfo().IsGenericType &&
-                    p.PropertyType.GetGenericTypeDefinition() = typedefof<Option<_>>
-
-                let isNullableType =
-                    p.PropertyType.GetTypeInfo().IsGenericType &&
-                    p.PropertyType.GetGenericTypeDefinition() = typedefof<Nullable<_>>
+                let isOptionType, isNullableType =
+                    if p.PropertyType.GetTypeInfo().IsGenericType
+                    then 
+                        let typeDef = p.PropertyType.GetGenericTypeDefinition()
+                        (typeDef = typedefof<Option<_>>, 
+                         typeDef = typedefof<Nullable<_>>) 
+                    else (false, false)                          
 
                 let propertyType =
                     if isOptionType || isNullableType then


### PR DESCRIPTION
Previously I was getting an error when binding records with `Nullable<_>` properties. 