### PR TITLE
SampleApp showing not proper url decoded string. 

### DIFF
--- a/samples/SampleApp/SampleApp.Tests/Tests.fs
+++ b/samples/SampleApp/SampleApp.Tests/Tests.fs
@@ -127,3 +127,12 @@ let ``Test /user/{id} returns success when logged in as user`` () =
     |> ensureSuccess
     |> readText
     |> shouldEqual "User ID: 1"
+
+[<Fact>]
+let ``Test url decode`` () =
+    use server = new TestServer(createHost())
+    use client = server.CreateClient()
+
+    get client "/encode/a%2Fb%2Bc.d%2Ce"
+    |> readText
+    |> shouldEqual "a/b+c.d,e"

--- a/samples/SampleApp/SampleApp/Program.fs
+++ b/samples/SampleApp/SampleApp/Program.fs
@@ -133,6 +133,7 @@ let webApp =
                 route  "/configured" >=> configuredHandler
                 route  "/upload"     >=> fileUploadHandler
                 route  "/upload2"    >=> fileUploadHandler2
+                routef "/encode/%s"  text
             ]
         route "/car"  >=> bindModel<Car> None json
         route "/car2" >=> tryBindQuery<Car> parsingErrorHandler None (validateModel xml)

--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -11,6 +11,9 @@ open Microsoft.FSharp.Reflection
 // ---------------------------
 
 let private formatStringMap =
+    let stringParser (str : string) =
+        str.Replace("%2F", "/")
+
     let guidFormatStr =
         "([0-9A-Fa-f]{8}\-[0-9A-Fa-f]{4}\-[0-9A-Fa-f]{4}\-[0-9A-Fa-f]{4}\-[0-9A-Fa-f]{12}|[0-9A-Fa-f]{32})"
 
@@ -19,7 +22,7 @@ let private formatStringMap =
     // -------------------------------------------------------------
         'b', ("(?i:(true|false)){1}",   bool.Parse           >> box)  // bool
         'c', ("(.{1})",                 char                 >> box)  // char
-        's', ("(.+)",                   WebUtility.UrlDecode >> box)  // string
+        's', ("(.+)",                   stringParser         >> box)  // string
         'i', ("(-?\d+)",                int32                >> box)  // int
         'd', ("(-?\d+)",                int64                >> box)  // int64
         'f', ("(-?\d+\.{1}\d+)",        float                >> box)  // float


### PR DESCRIPTION
a%2Fb%2Bc.d%2Ce 
gives 
a/b c.d,e 
and should gives 
a/b+c.d,e #254 