### PR TITLE
Make BindModelAsync also work on HTTP PATCH requests

### DIFF
--- a/src/Giraffe/ModelBinding.fs
+++ b/src/Giraffe/ModelBinding.fs
@@ -293,7 +293,7 @@ type HttpContext with
     member this.BindModelAsync<'T> (?cultureInfo : CultureInfo) =
         task {
             let method = this.Request.Method
-            if method.Equals "POST" || method.Equals "PUT" then
+            if method.Equals "POST" || method.Equals "PUT" || method.Equals "PATCH" then
                 let original = StringSegment(this.Request.ContentType)
                 let parsed   = ref (MediaTypeHeaderValue(StringSegment("*/*")))
                 return!


### PR DESCRIPTION
This would fix #279.

Rationale: the PATCH method ([RFC 5789](https://tools.ietf.org/html/rfc5789)) is designed for partial updates, which can be useful in a number of scenarios. It typically carries a body that is structured in some format defined by the Web application: a perfect fit for BindModelAsync. And as #279 and https://github.com/SaturnFramework/Saturn/issues/80 demonstrate, there's at least one real-world use case that could use this feature.

Furthermore, the implementation is trivial, as you can see from this PR. :-)