### PR TITLE
Enabled BindModelAsync<'T> for DELETE HTTP method

### DIFF
--- a/src/Giraffe/ModelBinding.fs
+++ b/src/Giraffe/ModelBinding.fs
@@ -293,7 +293,7 @@ type HttpContext with
     member this.BindModelAsync<'T> (?cultureInfo : CultureInfo) =
         task {
             let method = this.Request.Method
-            if method.Equals "POST" || method.Equals "PUT" || method.Equals "PATCH" then
+            if method.Equals "POST" || method.Equals "PUT" || method.Equals "PATCH" || method.Equals "DELETE" then
                 let original = StringSegment(this.Request.ContentType)
                 let parsed   = ref (MediaTypeHeaderValue(StringSegment("*/*")))
                 return!


### PR DESCRIPTION
Fix for
https://github.com/giraffe-fsharp/Giraffe/issues/287