### PR TITLE
added community blog post examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ If you add this source to your NuGet CLI or project settings then you can pull u
 - [Giraffe brings F# functional programming to ASP.Net Core](https://www.infoworld.com/article/3229005/web-development/f-and-functional-programming-come-to-asp-net-core.html) (by Paul Krill from InfoWorld)
 - [JSON Web Token with Giraffe and F#](https://medium.com/@dsincl12/json-web-token-with-giraffe-and-f-4cebe1c3ef3b) (by David Sinclair)
 - [WebSockets with Giraffe and F#](https://medium.com/@dsincl12/websockets-with-f-and-giraffe-772be829e121) (by David Sinclair)
+- [Use appsettings in a Giraffe web app](https://www.devprotocol.com/use-appsettings-in-a-giraffe-web-app/) (by Jan Tourlamain)
+- [Integrate Azure AD in your Giraffe web app](https://www.devprotocol.com/integrate-azure-ad-in-your-giraffe-web-app/) (by Jan Tourlamain)
 
 If you have blogged about Giraffe, demonstrating a useful topic or some other tips or tricks then please feel free to submit a pull request and add your article to this list as a reference for other Giraffe users. Thank you!
 


### PR DESCRIPTION
@dustinmoris I added two references in the readme.md file to 2 blogposts I wrote about Giraffe.

- A blogpost about using appsettings.json in a Giraffe web app
- A blogpost about integrating Azure AD in a Giraffe web app. This post also provides more info for #263 