### PR TITLE
Micro tuning of response writers

### DIFF
--- a/src/Giraffe/ResponseWriters.fs
+++ b/src/Giraffe/ResponseWriters.fs
@@ -9,6 +9,15 @@ open Microsoft.Net.Http.Headers
 open FSharp.Control.Tasks.V2.ContextInsensitive
 open Giraffe.GiraffeViewEngine
 
+let inline private nodeToUtf8HtmlDoc (node:XmlNode) : byte[] = 
+    let sb = new StringBuilder()
+    ViewBuilder.buildHtmlDocument sb node |> ignore
+    let chars = ArrayPool<char>.Shared.Rent(sb.Length)
+    sb.CopyTo(0, chars, 0, sb.Length)
+    let result = Encoding.UTF8.GetBytes(chars, 0, sb.Length)
+    ArrayPool<char>.Shared.Return chars
+    result
+
 // ---------------------------
 // HttpContext extensions
 // ---------------------------
@@ -193,15 +202,9 @@ type HttpContext with
     /// Task of `Some HttpContext` after writing to the body of the response.
     ///
     member this.WriteHtmlViewAsync (htmlView : XmlNode) =
-        let sb = new StringBuilder()
-        ViewBuilder.buildHtmlDocument sb htmlView |> ignore
-        let chars = ArrayPool<char>.Shared.Rent(sb.Length)
-        sb.CopyTo(0, chars, 0, sb.Length)
-        let result = Encoding.UTF8.GetBytes(chars, 0, sb.Length)
-        ArrayPool<char>.Shared.Return chars
-
+        let bytes = nodeToUtf8HtmlDoc htmlView
         this.SetContentType "text/html"
-        this.WriteBytesAsync result
+        this.WriteBytesAsync bytes
 
 // ---------------------------
 // HttpHandler functions
@@ -236,8 +239,9 @@ let setBody (bytes : byte array) : HttpHandler =
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
 ///
 let setBodyFromString (str : string) : HttpHandler =
+    let bytes = Encoding.UTF8.GetBytes(str)
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteStringAsync str
+        ctx.WriteBytesAsync bytes
 
 /// **Description**
 ///
@@ -252,8 +256,10 @@ let setBodyFromString (str : string) : HttpHandler =
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
 ///
 let text (str : string) : HttpHandler =
+    let bytes = Encoding.UTF8.GetBytes str
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteTextAsync str
+        ctx.SetContentType "text/plain"
+        ctx.WriteBytesAsync bytes
 
 /// **Description**
 ///
@@ -348,8 +354,10 @@ let htmlFile (filePath : string) : HttpHandler =
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
 ///
 let htmlString (html : string) : HttpHandler =
+    let bytes = Encoding.UTF8.GetBytes html
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteHtmlStringAsync html
+        ctx.SetContentType "text/html"
+        ctx.WriteBytesAsync bytes
 
 /// **Description**
 ///
@@ -366,5 +374,7 @@ let htmlString (html : string) : HttpHandler =
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
 ///
 let htmlView (htmlView : XmlNode) : HttpHandler =
+    let bytes = nodeToUtf8HtmlDoc htmlView
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteHtmlViewAsync htmlView
+        ctx.SetContentType "text/html"
+        ctx.WriteBytesAsync bytes


### PR DESCRIPTION
This is one file micro tuning pr based on results of the continuous run of techempower [tests ](https://www.techempower.com/benchmarks/#section=test&runid=a1843d12-6091-4780-92a6-a747fab77cb1&hw=ph&test=plaintext&p=zik0zj-zik0zj-zijocf-5m9r)

![image](https://user-images.githubusercontent.com/1162823/45919795-ca6eb600-bea3-11e8-9b0b-f8d005471afb.png)

There are 330_000 requests per second difference for this kind of benchmark between the utf8 encoding on each call vs utf8 encoding once in the constructor.

So I've moved utf8 encoding out of HTTP handlers where applicable.

I have not found a way to do the same thing for json because current serializer depends on an instance resolved from HTTP context