### PR TITLE
Replaced rawText with encodedText in samples + comments in GiraffeViewEngine

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2329,11 +2329,11 @@ Giraffe comes with its own extremely powerful view engine for functional develop
 let indexView =
     html [] [
         head [] [
-            title [] [ rawText "Giraffe" ]
+            title [] [ encodedText "Giraffe" ]
         ]
         body [] [
-            h1 [] [ rawText "Giraffe" ]
-            p [] [ rawText "Hello World." ]
+            h1 [] [ encodedText "Giraffe" ]
+            p [] [ encodedText "Hello World." ]
         ]
     ]
 
@@ -2702,12 +2702,12 @@ HTML elements and attributes are defined as F# objects:
 let indexView =
     html [] [
         head [] [
-            title [] [ rawText "Giraffe Sample" ]
+            title [] [ encodedText "Giraffe Sample" ]
         ]
         body [] [
             h1 [] [ encodedText "I |> F#" ]
             p [ _class "some-css-class"; _id "someId" ] [
-                rawText "Hello World"
+                encodedText "Hello World"
             ]
         ]
     ]
@@ -2726,7 +2726,7 @@ All `ParentNode` elements accept these two parameters:
 ```fsharp
 let someHtml =
     div [ _id "someId"; _class "css-class" ] [
-        a [ _href "https://example.org" ] [ rawText "Some text..." ]
+        a [ _href "https://example.org" ] [ encodedText "Some text..." ]
     ]
 ```
 
@@ -2737,7 +2737,7 @@ let someHtml =
     div [] [
         br []
         hr [ _class "css-class-for-hr" ]
-        p [] [ rawText "bla blah" ]
+        p [] [ encodedText "bla blah" ]
     ]
 ```
 
@@ -2781,7 +2781,7 @@ let someHtml =
     ]
 ```
 
-The `rawText` function will create an object of type `Text` where the content will be rendered in its original form and the `encodedText` function will output a string where the content has been HTML encoded.
+The `rawText` function will create an object of type `XmlNode` where the content will be rendered in its original form and the `encodedText` function will output a string where the content has been HTML encoded.
 
 In this example the first `p` element will literally output the string as it is (`<div>Hello World</div>`) while the second `p` element will output the value as HTML encoded string `&lt;div&gt;Hello World&lt;/div&gt;`.
 
@@ -2818,12 +2818,12 @@ module Views =
     let index =
         html [] [
             head [] [
-                title [] [ rawText "Giraffe Sample" ]
+                title [] [ encodedText "Giraffe Sample" ]
             ]
             body [] [
                 h1 [] [ encodedText "I |> F#" ]
                 p [ _class "some-css-class"; _id "someId" ] [
-                    rawText "Hello World"
+                    encodedText "Hello World"
                 ]
             ]
         ]

--- a/samples/GoogleAuthApp/GoogleAuthApp/Program.fs
+++ b/samples/GoogleAuthApp/GoogleAuthApp/Program.fs
@@ -35,56 +35,56 @@ module Views =
     let master (content: XmlNode list) =
         html [] [
             head [] [
-                title [] [ rawText "Google Auth Sample App" ]
+                title [] [ encodedText "Google Auth Sample App" ]
             ]
             body [] content
         ]
 
     let index =
         [
-            h1 [] [ rawText "Google Auth Sample App" ]
-            p [] [ rawText "Welcome to the Google Auth Sample App!" ]
+            h1 [] [ encodedText "Google Auth Sample App" ]
+            p [] [ encodedText "Welcome to the Google Auth Sample App!" ]
             ul [] [
-                li [] [ a [ _href Urls.login ] [ rawText "Login" ] ]
-                li [] [ a [ _href Urls.user ] [ rawText "User profile" ] ]
+                li [] [ a [ _href Urls.login ] [ encodedText "Login" ] ]
+                li [] [ a [ _href Urls.user ] [ encodedText "User profile" ] ]
             ]
         ] |> master
 
     let login =
         [
-            h1 [] [ rawText "Login" ]
-            p [] [ rawText "Pick one of the options to log in:" ]
+            h1 [] [ encodedText "Login" ]
+            p [] [ encodedText "Pick one of the options to log in:" ]
             ul [] [
-                li [] [ a [ _href Urls.googleAuth ] [ rawText "Google" ] ]
-                li [] [ a [ _href Urls.missing ] [ rawText "Facebook" ] ]
-                li [] [ a [ _href Urls.missing ] [ rawText "Twitter" ] ]
+                li [] [ a [ _href Urls.googleAuth ] [ encodedText "Google" ] ]
+                li [] [ a [ _href Urls.missing ] [ encodedText "Facebook" ] ]
+                li [] [ a [ _href Urls.missing ] [ encodedText "Twitter" ] ]
             ]
             p [] [
-                a [ _href Urls.index ] [ rawText "Return to home." ]
+                a [ _href Urls.index ] [ encodedText "Return to home." ]
             ]
         ] |> master
 
     let user (claims : (string * string) seq) =
         [
-            h1 [] [ rawText "User details" ]
-            h2 [] [ rawText "Claims:" ]
+            h1 [] [ encodedText "User details" ]
+            h2 [] [ encodedText "Claims:" ]
             ul [] [
                 yield! claims |> Seq.map (
                     fun (key, value) ->
                         li [] [ sprintf "%s: %s" key value |> encodedText ] )
             ]
             p [] [
-                a [ _href Urls.logout ] [ rawText "Logout" ]
+                a [ _href Urls.logout ] [ encodedText "Logout" ]
             ]
         ] |> master
 
     let notFound =
         [
-            h1 [] [ rawText "Not Found" ]
-            p [] [ rawText "The requested resource does not exist." ]
-            p [] [ rawText "Facebook and Twitter auth handlers have not been configured yet." ]
+            h1 [] [ encodedText "Not Found" ]
+            p [] [ encodedText "The requested resource does not exist." ]
+            p [] [ encodedText "Facebook and Twitter auth handlers have not been configured yet." ]
             ul [] [
-                li [] [ a [ _href Urls.index ] [ rawText "Return to home." ] ]
+                li [] [ a [ _href Urls.index ] [ encodedText "Return to home." ] ]
             ]
         ] |> master
 

--- a/samples/IdentityApp/IdentityApp/Program.fs
+++ b/samples/IdentityApp/IdentityApp/Program.fs
@@ -35,10 +35,10 @@ let masterPage (pageTitle : string) (content : XmlNode list) =
 let indexPage =
     [
         p [] [
-            a [ _href "/register" ] [ rawText "Register" ]
+            a [ _href "/register" ] [ encodedText "Register" ]
         ]
         p [] [
-            a [ _href "/user" ] [ rawText "User page" ]
+            a [ _href "/user" ] [ encodedText "User page" ]
         ]
     ] |> masterPage "Home"
 
@@ -46,15 +46,15 @@ let registerPage =
     [
         form [ _action "/register"; _method "POST" ] [
             div [] [
-                label [] [ rawText "Email:" ]
+                label [] [ encodedText "Email:" ]
                 input [ _name "Email"; _type "text" ]
             ]
             div [] [
-                label [] [ rawText "User name:" ]
+                label [] [ encodedText "User name:" ]
                 input [ _name "UserName"; _type "text" ]
             ]
             div [] [
-                label [] [ rawText "Password:" ]
+                label [] [ encodedText "Password:" ]
                 input [ _name "Password"; _type "password" ]
             ]
             input [ _type "submit" ]
@@ -63,22 +63,22 @@ let registerPage =
 
 let loginPage (loginFailed : bool) =
     [
-        if loginFailed then yield p [ _style "color: Red;" ] [ rawText "Login failed." ]
+        if loginFailed then yield p [ _style "color: Red;" ] [ encodedText "Login failed." ]
 
         yield form [ _action "/login"; _method "POST" ] [
             div [] [
-                label [] [ rawText "User name:" ]
+                label [] [ encodedText "User name:" ]
                 input [ _name "UserName"; _type "text" ]
             ]
             div [] [
-                label [] [ rawText "Password:" ]
+                label [] [ encodedText "Password:" ]
                 input [ _name "Password"; _type "password" ]
             ]
             input [ _type "submit" ]
         ]
         yield p [] [
-            rawText "Don't have an account yet?"
-            a [ _href "/register" ] [ rawText "Go to registration" ]
+            encodedText "Don't have an account yet?"
+            a [ _href "/register" ] [ encodedText "Go to registration" ]
         ]
     ] |> masterPage "Login"
 

--- a/src/Giraffe/GiraffeViewEngine.fs
+++ b/src/Giraffe/GiraffeViewEngine.fs
@@ -60,9 +60,18 @@ let voidTag (tagName    : string)
             (attributes : XmlAttribute list) =
     VoidElement (tagName, Array.ofList attributes)
 
+/// The `encodedText` function will output a string where the content has been HTML encoded.
 let encodedText (content : string) = Text (encode content)
+
+/// The `rawText` function will create an object of type `XmlNode` where the content will be rendered in its original form (without encoding).
+///
+/// Please be aware that the the usage of `rawText` is mainly designed for edge cases where someone would purposefully want to inject HTML (or JavaScript) code into a rendered view. If not used carefully this could potentially lead to serious security vulnerabilities and therefore should be used only when explicitly required.
+///
+/// Most cases and particularly any user provided content should always be output via the `encodedText` function.
 let rawText     (content : string) = Text content
+
 let emptyText                      = rawText ""
+
 let comment     (content : string) = rawText (sprintf "<!-- %s -->" content)
 
 // ---------------------------


### PR DESCRIPTION
Documentation changes for #315 

Funnily enough, (not in this commit) added encoded cases to `HtmlUtf8Benchmark`, and the default one became 3% faster than the original Default.

