### PR TITLE
Add shebang and fix shellcheck warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,4 @@
-export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
+#!/bin/sh
+FrameworkPathOverride=$(dirname "$(which mono)")/../lib/mono/4.5/
+export FrameworkPathOverride
 pwsh ./build.ps1


### PR DESCRIPTION
This PR resolves issue #321.

Tried running the build script on macOS, got the following error:

```
Failed to execute process './build.sh'. Reason:
exec: Exec format error
The file './build.sh' is marked as an executable but could not be run by the operating system.
```

Looked at the script and saw there was no shebang, so I added the default `#!/bin/sh`.

Ran `$ shellcheck build.sh` and got:

```
export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
       ^-- SC2155: Declare and assign separately to avoid masking return values.
                                       ^-- SC2046: Quote this to prevent word splitting.
```

So I fixed those errors. Now if `pwsh` isn't in the user's `$PATH`, the command will helpfully inform them.
