### PR TITLE
Add handleContextAsync and handleRequestAsync with docs

### DIFF
--- a/.psscripts/build-functions.ps1
+++ b/.psscripts/build-functions.ps1
@@ -309,8 +309,12 @@ function Install-NetCoreSdkFromArchive ($sdkArchivePath)
         Write-Host "Created folder '$env:DOTNET_INSTALL_DIR'."
         Expand-Archive -LiteralPath $sdkArchivePath -DestinationPath $env:DOTNET_INSTALL_DIR -Force
         Write-Host "Extracted '$sdkArchivePath' to folder '$env:DOTNET_INSTALL_DIR'."
-        $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
-        Write-Host "Added '$env:DOTNET_INSTALL_DIR' to the environment variables."
+        $updatedPath = "$env:DOTNET_INSTALL_DIR;$env:Path"
+        [Environment]::SetEnvironmentVariable("Path", $updatedPath, "Process")
+        [Environment]::SetEnvironmentVariable("Path", $updatedPath, "User")
+        [Environment]::SetEnvironmentVariable("Path", $updatedPath, "Machine")
+        Write-Host "Added '$dotnetInstallDir' to the Path environment variable:"
+        Write-Host $env:Path
     }
     else
     {
@@ -323,7 +327,8 @@ function Install-NetCoreSdkFromArchive ($sdkArchivePath)
         [Environment]::SetEnvironmentVariable("PATH", $updatedPath, "Process")
         [Environment]::SetEnvironmentVariable("PATH", $updatedPath, "User")
         [Environment]::SetEnvironmentVariable("PATH", $updatedPath, "Machine")
-        Write-Host "Added '$dotnetInstallDir' to the environment variables."
+        Write-Host "Added '$dotnetInstallDir' to the PATH environment variable:"
+        Write-Host $env:PATH
     }
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
   - sudo apt-get update
   - sudo apt-get install -y powershell
-  - pwsh ./.psscripts/install-dotnet.ps1
+  - sudo pwsh ./.psscripts/install-dotnet.ps1
 
 script:
   - export PATH=/home/travis/.dotnetsdk:$PATH

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -247,44 +247,40 @@ let sayHelloWorld : HttpHandler =
         }
 ```
 
-#### Convenience functions
+#### handleContext
 
-With version 3.5.0 and onwards Giraffe exposes additional convenience functions which can be used to create new `HttpHandler` functions which require access to the `HttpContext` or `HttpRequest` object without having to define the full verbose implementation as shown above.
+Starting with version 3.5.0 and onwards Giraffe exposes an additional convenience function which can be used to generate new handler functions which only require access to the `HttpContext` object without having to define the full verbose implementation as shown above.
 
-The `handleContext` and `handleRequest` functions, along with their asynchronous counter parts `handleContextAsync` and `handleRequestAsync` can be used like this:
+The `handleContext` function can be used like this:
 
 ```fsharp
-let handlerWithLogging =
+let handlerWithLogging : HttpHandler =
     handleContext(
         fun ctx ->
             let logger = ctx.GetService<ILogger>()
-            logger.Information("From the context")
-            text "Done working")
-
-let echoRequestBody =
-    POST
-    >=> route "/echo"
-    >=> handleRequest(
-        fun req ->
-            use reader = new StreamReader(req.Body)
-            let requestBody = reader.ReadToEnd()
-            text requestBody)
-
-let echoRequestBodyAsync = 
-    POST 
-    >=> route "/echo-async"
-    >=> handleRequestAsync(
-        fun request ->
-            task {
-                use reader = new StreamReader(request.Body)
-                let! requestBody = reader.ReadToEndAsync()
-                return text requestBody
-            })    
+            logger.LogInformation("From the context")
+            ctx.WriteTextAsync "")
 ```
+
+Or alternatively if additional asynchronous work needs to be done:
+
+```fsharp
+let handlerWithLogging2 : HttpHandler =
+    handleContext(
+        fun ctx ->
+            task {
+                let logger = ctx.GetService<ILogger>()
+                logger.LogInformation("From the context")
+                // Do more async stuff
+                return! ctx.WriteTextAsync "Done working"
+            })
+```
+
+Please note that the `handleContext` function doesn't have control over the `next` handler and therefore cannot "skip" the handler pipeline like normal `HttpHandler` functions can do (see: [Continue vs. Return vs. Skip](#continue-vs-return-vs-skip)).
 
 #### Deferred execution of Tasks
 
-Please be aware that a `Task<'T>` in .NET is just a promise of `'T` when executed asynchronously. Unless you define a `HttpHandler` function in the most verbose way with the `task {}` CE you are not executing any asynchronous operations until the handler gets invoked by the `GiraffeMiddleware`.
+Please be also aware that a `Task<'T>` in .NET is just a promise of `'T` when executed asynchronously. Unless you define a `HttpHandler` function in the most verbose way with the `task {}` CE you are not executing any asynchronous operations until the handler gets invoked by the `GiraffeMiddleware`.
 
 For example, in the example below, an `IDisposable` will get disposed **before** the actual `handler` gets executed:
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -276,9 +276,9 @@ let echoRequestBodyAsync =
     >=> handleRequestAsync(
         fun request ->
             task {
-                use reader = new StreamReader(req.Body)
+                use reader = new StreamReader(request.Body)
                 let! requestBody = reader.ReadToEndAsync()
-                text requestBody
+                return text requestBody
             })    
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -251,7 +251,7 @@ let sayHelloWorld : HttpHandler =
 
 With version 3.5.0 and onwards Giraffe exposes additional convenience functions which can be used to create new `HttpHandler` functions which require access to the `HttpContext` or `HttpRequest` object without having to define the full verbose implementation as shown above.
 
-The `handleContext` and `handleRequest` functions can be used like this:
+The `handleContext` and `handleRequest` functions, along with their asynchronous counter parts `handleContextAsync` and `handleRequestAsync` can be used like this:
 
 ```fsharp
 let handlerWithLogging =
@@ -266,9 +266,20 @@ let echoRequestBody =
     >=> route "/echo"
     >=> handleRequest(
         fun req ->
-            use reader = StreamReader(req.Body)
-            requestBody = reader.ReadToEnd()
+            use reader = new StreamReader(req.Body)
+            let requestBody = reader.ReadToEnd()
             text requestBody)
+
+let echoRequestBodyAsync = 
+    POST 
+    >=> route "/echo-async"
+    >=> handleRequestAsync(
+        fun request ->
+            task {
+                use reader = new StreamReader(req.Body)
+                let! requestBody = reader.ReadToEndAsync()
+                text requestBody
+            })    
 ```
 
 #### Deferred execution of Tasks

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Release Notes
 
 - Updated all packages and framework library dependencies to .NET Core 2.2.
 - Added a new `GET_HEAD` http handler (see: [#314](https://github.com/giraffe-fsharp/Giraffe/issues/314) for more info).
-- Added two new convenience functions, `handleContext` and `handleRequest`, which can be used for creating new `HttpHandler` functions.
+- Added new convenience functions: `handleContext`, `handleContextAsync`, `handleRequest` and `handleRequestAsync`, which can be used for creating new `HttpHandler` functions.
 
 #### Bug fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Release Notes
 
 - Updated all packages and framework library dependencies to .NET Core 2.2.
 - Added a new `GET_HEAD` http handler (see: [#314](https://github.com/giraffe-fsharp/Giraffe/issues/314) for more info).
-- Added new convenience functions: `handleContext`, `handleContextAsync`, `handleRequest` and `handleRequestAsync`, which can be used for creating new `HttpHandler` functions.
+- Added a new convenience function called `handleContext`, which can be used for creating new `HttpHandler` functions.
 
 #### Bug fixes
 

--- a/src/Giraffe/Auth.fs
+++ b/src/Giraffe/Auth.fs
@@ -14,7 +14,7 @@ open FSharp.Control.Tasks.V2.ContextInsensitive
 ///
 /// **Parameters**
 ///
-/// - `authScheme`: The name of an authentication scheme from your application.
+/// `authScheme`: The name of an authentication scheme from your application.
 ///
 /// **Output**
 ///
@@ -33,7 +33,7 @@ let challenge (authScheme : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `authScheme`: The name of an authentication scheme from your application.
+/// `authScheme`: The name of an authentication scheme from your application.
 ///
 /// **Output**
 ///
@@ -52,8 +52,8 @@ let signOut (authScheme : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `policy`: One or many conditions which a `HttpContext` must meet. The `policy` function should return `true` on success and `false` on failure.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
+/// `policy`: One or many conditions which a `HttpContext` must meet. The `policy` function should return `true` on success and `false` on failure.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
 ///
 /// **Output**
 ///
@@ -69,8 +69,8 @@ let authorizeRequest (predicate : HttpContext -> bool) (authFailedHandler : Http
 ///
 /// **Parameters**
 ///
-/// - `policy`: One or many conditions which a `ClaimsPrincipal` must meet. The `policy` function should return `true` on success and `false` on failure.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
+/// `policy`: One or many conditions which a `ClaimsPrincipal` must meet. The `policy` function should return `true` on success and `false` on failure.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
 ///
 /// **Output**
 ///
@@ -88,8 +88,8 @@ let evaluateUserPolicy (policy : ClaimsPrincipal -> bool) (authFailedHandler : H
 ///
 /// **Parameters**
 ///
-/// - `policy`: One or many conditions which a `ClaimsPrincipal` must meet. The `policy` function should return `true` on success and `false` on failure.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
+/// `policy`: One or many conditions which a `ClaimsPrincipal` must meet. The `policy` function should return `true` on success and `false` on failure.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when the `policy` returns `false`.
 ///
 /// **Output**
 ///
@@ -103,7 +103,7 @@ let authorizeUser = evaluateUserPolicy
 ///
 /// **Parameters**
 ///
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when authentication failed.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when authentication failed.
 ///
 /// **Output**
 ///
@@ -120,8 +120,8 @@ let requiresAuthentication (authFailedHandler : HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `role`: The required role of which a user must be a member of in order to pass the validation.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
+/// `role`: The required role of which a user must be a member of in order to pass the validation.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
 ///
 /// **Output**
 ///
@@ -138,8 +138,8 @@ let requiresRole (role : string) (authFailedHandler : HttpHandler) : HttpHandler
 ///
 /// **Parameters**
 ///
-/// - `roles`: A list of roles of which a user must be a member of (minimum one) in order to pass the validation.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
+/// `roles`: A list of roles of which a user must be a member of (minimum one) in order to pass the validation.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
 ///
 /// **Output**
 ///
@@ -156,8 +156,8 @@ let requiresRoleOf (roles : string list) (authFailedHandler : HttpHandler) : Htt
 ///
 /// **Parameters**
 ///
-/// - `policyName`: The name of an `AuthorizationPolicy` which a user must meet in order to pass the validation.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
+/// `policyName`: The name of an `AuthorizationPolicy` which a user must meet in order to pass the validation.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
 ///
 /// **Output**
 ///
@@ -177,8 +177,8 @@ let authorizeByPolicyName (policyName : string) (authFailedHandler : HttpHandler
 ///
 /// **Parameters**
 ///
-/// - `policy`: An `AuthorizationPolicy` which a user must meet in order to pass the validation.
-/// - `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
+/// `policy`: An `AuthorizationPolicy` which a user must meet in order to pass the validation.
+/// `authFailedHandler`: A `HttpHandler` function which will be executed when validation fails.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Common.fs
+++ b/src/Giraffe/Common.fs
@@ -49,7 +49,7 @@ type DateTimeOffset with
 ///
 /// **Parameters**
 ///
-/// - `x`: The object to validate against `null`.
+/// `x`: The object to validate against `null`.
 ///
 /// **Output**
 ///
@@ -63,7 +63,7 @@ let inline isNotNull x = not (isNull x)
 ///
 /// **Parameters**
 ///
-/// - `str`: The string value to be converted into an option of string.
+/// `str`: The string value to be converted into an option of string.
 ///
 /// **Output**
 ///
@@ -78,7 +78,7 @@ let inline strOption (str : string) =
 ///
 /// **Parameters**
 ///
-/// - `filePath`: The absolute path of the file.
+/// `filePath`: The absolute path of the file.
 ///
 /// **Output**
 ///
@@ -124,7 +124,7 @@ module ShortGuid =
     ///
     /// **Parameters**
     ///
-    /// - `guid`: The `System.Guid` to be converted into a short GUID.
+    /// `guid`: The `System.Guid` to be converted into a short GUID.
     ///
     /// **Output**
     ///
@@ -144,7 +144,7 @@ module ShortGuid =
     ///
     /// **Parameters**
     ///
-    /// - `shortGuid`: The short GUID string to be converted into a `System.Guid`.
+    /// `shortGuid`: The short GUID string to be converted into a `System.Guid`.
     ///
     /// **Output**
     ///
@@ -187,7 +187,7 @@ module ShortId =
     ///
     /// **Parameters**
     ///
-    /// - `id`: The `uint64` to be converted into a short ID.
+    /// `id`: The `uint64` to be converted into a short ID.
     ///
     /// **Output**
     ///
@@ -211,7 +211,7 @@ module ShortId =
     ///
     /// **Parameters**
     ///
-    /// - `shortId`: The short ID string to be converted into a `uint64` value.
+    /// `shortId`: The short ID string to be converted into a `uint64` value.
     ///
     /// **Output**
     ///

--- a/src/Giraffe/ComputationExpressions.fs
+++ b/src/Giraffe/ComputationExpressions.fs
@@ -2,8 +2,8 @@
 ///
 /// A collection of F# computation expressions:
 ///
-/// - `opt {}`: Enables control flow and binding of Option<'T> objects
-/// - `res {}`: Enables control flow and binding of Result<'T, 'TError> objects
+/// `opt {}`: Enables control flow and binding of Option<'T> objects
+/// `res {}`: Enables control flow and binding of Result<'T, 'TError> objects
 ///
 module Giraffe.ComputationExpressions
 

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -70,7 +70,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `categoryName`: The category name for messages produced by this logger.
+    /// `categoryName`: The category name for messages produced by this logger.
     ///
     /// **Output**
     ///
@@ -119,7 +119,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `httpStatusCode`: The status code to be set in the response. For convenience you can use the static `Microsoft.AspNetCore.Http.StatusCodes` class for passing in named status codes instead of using pure `int` values.
+    /// `httpStatusCode`: The status code to be set in the response. For convenience you can use the static `Microsoft.AspNetCore.Http.StatusCodes` class for passing in named status codes instead of using pure `int` values.
     ///
     /// **Output**
     ///
@@ -134,8 +134,8 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `key`: The HTTP header name. For convenience you can use the static `Microsoft.Net.Http.Headers.HeaderNames` class for passing in strongly typed header names instead of using pure `string` values.
-    /// - `value`: The value to be set. Non string values will be converted to a string using the object's `ToString()` method.
+    /// `key`: The HTTP header name. For convenience you can use the static `Microsoft.Net.Http.Headers.HeaderNames` class for passing in strongly typed header names instead of using pure `string` values.
+    /// `value`: The value to be set. Non string values will be converted to a string using the object's `ToString()` method.
     ///
     /// **Output**
     ///
@@ -150,7 +150,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `contentType`: The mime type of the response (e.g.: `application/json` or `text/html`).
+    /// `contentType`: The mime type of the response (e.g.: `application/json` or `text/html`).
     ///
     /// **Output**
     ///
@@ -165,7 +165,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `key`: The name of the HTTP header.
+    /// `key`: The name of the HTTP header.
     ///
     /// **Output**
     ///
@@ -182,7 +182,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `key`: The name of the HTTP header.
+    /// `key`: The name of the HTTP header.
     ///
     /// **Output**
     ///
@@ -199,7 +199,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `key`: The name of the query string parameter.
+    /// `key`: The name of the query string parameter.
     ///
     /// **Output**
     ///
@@ -216,7 +216,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `key`: The name of the query string parameter.
+    /// `key`: The name of the query string parameter.
     ///
     /// **Output**
     ///
@@ -271,7 +271,7 @@ type ErrorHandler = exn -> ILogger -> HttpHandler
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which takes a `HttpFunc * HttpContext` tuple and returns a `HttpHandler` function.
+/// `f`: A function which takes a `HttpFunc * HttpContext` tuple and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
@@ -305,11 +305,12 @@ let earlyReturn : HttpFunc = Some >> Task.FromResult
 ///
 /// **Parameters**
 ///
-/// - `contextMap`: A function which accepts a `HttpContext` object and returns a `HttpHandler` function.
+/// `contextMap`: A function which accepts a `HttpContext` object and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
+///
 let handleContext (contextMap : HttpContext -> HttpHandler) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         let createdHandler = contextMap ctx
@@ -321,11 +322,12 @@ let handleContext (contextMap : HttpContext -> HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `contextMap`: A function which accepts a `HttpContext` object and returns a `HttpHandler` function asynchronously.
+/// `contextMap`: A function which accepts a `HttpContext` object and returns a `HttpHandler` function asynchronously.
 ///
 /// **Output**
 ///
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
+///
 let handleContextAsync (contextMap : HttpContext -> Task<HttpHandler>) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         task {
@@ -339,11 +341,12 @@ let handleContextAsync (contextMap : HttpContext -> Task<HttpHandler>) : HttpHan
 ///
 /// **Parameters**
 ///
-/// - `requestMap`: A function which accepts a `HttpRequest` object and returns a `HttpHandler` function.
+/// `requestMap`: A function which accepts a `HttpRequest` object and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
+///
 let handleRequest (requestMap : HttpRequest -> HttpHandler) : HttpHandler =
     handleContext (fun ctx -> requestMap ctx.Request)
 
@@ -353,7 +356,7 @@ let handleRequest (requestMap : HttpRequest -> HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `requestMap`: A function which accepts a `HttpRequest` object and returns a `HttpHandler` function asynchronously.
+/// `requestMap`: A function which accepts a `HttpRequest` object and returns a `HttpHandler` function asynchronously.
 ///
 /// **Output**
 ///
@@ -427,7 +430,7 @@ let choose (handlers : HttpHandler list) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `validate`: A validation function which checks for a single HTTP verb.
+/// `validate`: A validation function which checks for a single HTTP verb.
 ///
 /// **Output**
 ///
@@ -472,7 +475,7 @@ let clearResponse : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `statusCode`: The status code to be set in the response. For convenience you can use the static `Microsoft.AspNetCore.Http.StatusCodes` class for passing in named status codes instead of using pure `int` values.
+/// `statusCode`: The status code to be set in the response. For convenience you can use the static `Microsoft.AspNetCore.Http.StatusCodes` class for passing in named status codes instead of using pure `int` values.
 ///
 /// **Output**
 ///
@@ -489,8 +492,8 @@ let setStatusCode (statusCode : int) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `key`: The HTTP header name. For convenience you can use the static `Microsoft.Net.Http.Headers.HeaderNames` class for passing in strongly typed header names instead of using pure `string` values.
-/// - `value`: The value to be set. Non string values will be converted to a string using the object's `ToString()` method.
+/// `key`: The HTTP header name. For convenience you can use the static `Microsoft.Net.Http.Headers.HeaderNames` class for passing in strongly typed header names instead of using pure `string` values.
+/// `value`: The value to be set. Non string values will be converted to a string using the object's `ToString()` method.
 ///
 /// **Output**
 ///
@@ -509,7 +512,7 @@ let setHttpHeader (key : string) (value : obj) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `mimeTypes`: List of mime types of which the client has to accept at least one.
+/// `mimeTypes`: List of mime types of which the client has to accept at least one.
 ///
 /// **Output**
 ///
@@ -531,14 +534,14 @@ let mustAccept (mimeTypes : string list) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `permanent`: If true the redirect is permanent (301), otherwise temporary (302).
-/// - `location`: The URL to redirect the client to.
+/// `permanent`: If true the redirect is permanent (301), otherwise temporary (302).
+/// `location`: The URL to redirect the client to.
 ///
 /// **Output**
 ///
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
-/// 
+///
 let redirectTo (permanent : bool) (location : string) : HttpHandler  =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         ctx.Response.Redirect(location, permanent)
-        Task.FromResult (Some ctx)  
+        Task.FromResult (Some ctx)

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -317,6 +317,24 @@ let handleContext (contextMap : HttpContext -> HttpHandler) : HttpHandler =
 
 /// **Description**
 ///
+/// The `handleContextAsync` function is a convenience function which can be used to create a new `HttpHandler` function asynchronously which requires access to the `HttpContext` object.
+///
+/// **Parameters**
+///
+/// - `contextMap`: A function which accepts a `HttpContext` object and returns a `HttpHandler` function asynchronously.
+///
+/// **Output**
+///
+/// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
+let handleContextAsync (contextMap : HttpContext -> Task<HttpHandler>) : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
+            let! evaluatedHandler = contextMap ctx
+            return! evaluatedHandler next ctx
+        }
+
+/// **Description**
+///
 /// The `handleRequest` function is a convenience function which can be used to create a new `HttpHandler` function which requires access to the `HttpRequest` object.
 ///
 /// **Parameters**
@@ -328,6 +346,20 @@ let handleContext (contextMap : HttpContext -> HttpHandler) : HttpHandler =
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
 let handleRequest (requestMap : HttpRequest -> HttpHandler) : HttpHandler =
     handleContext (fun ctx -> requestMap ctx.Request)
+
+/// **Description**
+///
+/// The `handleRequestAsync` function is a convenience function which can be used to create a new `HttpHandler` function asynchronously which requires access to the `HttpRequest` object.
+///
+/// **Parameters**
+///
+/// - `requestMap`: A function which accepts a `HttpRequest` object and returns a `HttpHandler` function asynchronously.
+///
+/// **Output**
+///
+/// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
+let handleRequestAsync (requestMap : HttpRequest -> Task<HttpHandler>) : HttpHandler =
+    handleContextAsync (fun ctx -> requestMap ctx.Request)
 
 // ---------------------------
 // Default Combinators
@@ -505,8 +537,8 @@ let mustAccept (mimeTypes : string list) : HttpHandler =
 /// **Output**
 ///
 /// A Giraffe `HttpHandler` function which can be composed into a bigger web application.
-///
+/// 
 let redirectTo (permanent : bool) (location : string) : HttpHandler  =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         ctx.Response.Redirect(location, permanent)
-        Task.FromResult (Some ctx)
+        Task.FromResult (Some ctx)  

--- a/src/Giraffe/FormatExpressions.fs
+++ b/src/Giraffe/FormatExpressions.fs
@@ -71,8 +71,8 @@ let private convertToRegexPatternAndFormatChars (formatString : string) =
 ///
 /// **Parameters**
 ///
-/// - `format`: The format string which shall be used for parsing.
-/// - `input`: The input string from which the parsed arguments shall be extracted.
+/// `format`: The format string which shall be used for parsing.
+/// `input`: The input string from which the parsed arguments shall be extracted.
 ///
 /// **Output**
 ///
@@ -133,7 +133,7 @@ let tryMatchInput (format : PrintfFormat<_,_,_,_, 'T>) (input : string) (ignoreC
 ///
 /// **Parameters**
 ///
-/// - `format`: The format string which shall be used for parsing.
+/// `format`: The format string which shall be used for parsing.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -85,7 +85,7 @@ type IApplicationBuilder with
     ///
     /// **Parameters**
     ///
-    /// - `handler`: The Giraffe `HttpHandler` pipeline. The handler can be anything from a single handler to an entire web application which has been composed from many smaller handlers.
+    /// `handler`: The Giraffe `HttpHandler` pipeline. The handler can be anything from a single handler to an entire web application which has been composed from many smaller handlers.
     ///
     /// **Output**
     ///
@@ -101,7 +101,7 @@ type IApplicationBuilder with
     ///
     /// **Parameters**
     ///
-    /// - `handler`: The Giraffe `ErrorHandler` pipeline. The handler can be anything from a single handler to a bigger error application which has been composed from many smaller handlers.
+    /// `handler`: The Giraffe `ErrorHandler` pipeline. The handler can be anything from a single handler to a bigger error application which has been composed from many smaller handlers.
     ///
     /// **Output**
     ///

--- a/src/Giraffe/ModelBinding.fs
+++ b/src/Giraffe/ModelBinding.fs
@@ -176,8 +176,8 @@ module ModelParser =
     ///
     /// **Parameters**
     ///
-    /// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
-    /// - `data`: A key-value dictionary of values for each property of type `'T`. Only optional properties can be omitted from the dictionary.
+    /// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `data`: A key-value dictionary of values for each property of type `'T`. Only optional properties can be omitted from the dictionary.
     ///
     /// **Output**
     ///
@@ -195,8 +195,8 @@ module ModelParser =
     ///
     /// **Parameters**
     ///
-    /// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
-    /// - `data`: A key-value dictionary of values for each property of type `'T`.
+    /// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `data`: A key-value dictionary of values for each property of type `'T`.
     ///
     /// **Output**
     ///
@@ -263,7 +263,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
     ///
     /// **Output**
     ///
@@ -285,7 +285,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
     ///
     /// **Output**
     ///
@@ -307,7 +307,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
     ///
     /// **Output**
     ///
@@ -325,7 +325,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
     ///
     /// **Output**
     ///
@@ -343,7 +343,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
+    /// `cultureInfo`: An optional `CultureInfo` element which will be used to parse culture specific data such as `float`, `DateTime` or `decimal` values.
     ///
     /// **Output**
     ///
@@ -377,7 +377,7 @@ type HttpContext with
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
@@ -396,7 +396,7 @@ let bindJson<'T> (f : 'T -> HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
@@ -415,8 +415,8 @@ let bindXml<'T> (f : 'T -> HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
-/// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+/// `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
 ///
 /// **Output**
 ///
@@ -440,9 +440,9 @@ let bindForm<'T> (culture : CultureInfo option) (f : 'T -> HttpHandler) : HttpHa
 ///
 /// **Parameters**
 ///
-/// - `parsingErrorHandler`: A `string -> HttpHandler` function which will get invoked when the model parsing fails. The `string` parameter holds the parsing error message.
-/// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
-/// - `successhandler`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `parsingErrorHandler`: A `string -> HttpHandler` function which will get invoked when the model parsing fails. The `string` parameter holds the parsing error message.
+/// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+/// `successhandler`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
@@ -469,8 +469,8 @@ let tryBindForm<'T> (parsingErrorHandler : string -> HttpHandler)
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
-/// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+/// `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
 ///
 /// **Output**
 ///
@@ -492,9 +492,9 @@ let bindQuery<'T> (culture : CultureInfo option) (f : 'T -> HttpHandler) : HttpH
 ///
 /// **Parameters**
 ///
-/// - `parsingErrorHandler`: A `HttpHandler` function which will get invoked when the model parsing fails. The `string` input parameter holds the parsing error message.
-/// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
-/// - `successhandler`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `parsingErrorHandler`: A `HttpHandler` function which will get invoked when the model parsing fails. The `string` input parameter holds the parsing error message.
+/// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+/// `successhandler`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
 ///
 /// **Output**
 ///
@@ -520,8 +520,8 @@ let tryBindQuery<'T> (parsingErrorHandler : string -> HttpHandler)
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
-/// - `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
+/// `f`: A function which accepts an object of type `'T` and returns a `HttpHandler` function.
+/// `culture`: An optional `CultureInfo` element to be used when parsing culture specific data such as `float`, `DateTime` or `decimal` values.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/ModelValidation.fs
+++ b/src/Giraffe/ModelValidation.fs
@@ -22,8 +22,8 @@ type IModelValidation<'T> =
 ///
 /// **Parameters**
 ///
-/// - `f`: A function which accepts the model `'T` and returns a `HttpHandler` function.
-/// - `model`: An instance of type `'T`, where `'T` must implement interface `IModelValidation<'T>`.
+/// `f`: A function which accepts the model `'T` and returns a `HttpHandler` function.
+/// `model`: An instance of type `'T`, where `'T` must implement interface `IModelValidation<'T>`.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Negotiation.fs
+++ b/src/Giraffe/Negotiation.fs
@@ -38,11 +38,11 @@ type INegotiationConfig =
 ///
 /// **Supported mime types**
 ///
-/// - `*/*`: If a client accepts any content type then the server will return a JSON response.
-/// - `application/json`: Server will send a JSON response.
-/// - `application/xml`: Server will send an XML response.
-/// - `text/xml`: Server will send an XML response.
-/// - `text/plain`: Server will send a plain text response (by suing an object's `ToString()` method).
+/// `*/*`: If a client accepts any content type then the server will return a JSON response.
+/// `application/json`: Server will send a JSON response.
+/// `application/xml`: Server will send an XML response.
+/// `text/xml`: Server will send an XML response.
+/// `text/plain`: Server will send a plain text response (by suing an object's `ToString()` method).
 ///
 type DefaultNegotiationConfig() =
     interface INegotiationConfig with
@@ -74,9 +74,9 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `negotiationRules`: A dictionary of mime types and response writing `HttpHandler` functions. Each mime type must be mapped to a function which accepts an `obj` and returns a `HttpHandler` which will send a response in the associated mime type (e.g.: `dict [ "application/json", json; "application/xml" , xml ]`).
-    /// - `unacceptableHandler`: A `HttpHandler` function which will be invoked if none of the accepted mime types can be satisfied. Generally this `HttpHandler` would send a response with a status code of `406 Unacceptable`.
-    /// - `responseObj`: The object to send back to the client.
+    /// `negotiationRules`: A dictionary of mime types and response writing `HttpHandler` functions. Each mime type must be mapped to a function which accepts an `obj` and returns a `HttpHandler` which will send a response in the associated mime type (e.g.: `dict [ "application/json", json; "application/xml" , xml ]`).
+    /// `unacceptableHandler`: A `HttpHandler` function which will be invoked if none of the accepted mime types can be satisfied. Generally this `HttpHandler` would send a response with a status code of `406 Unacceptable`.
+    /// `responseObj`: The object to send back to the client.
     ///
     /// **Output**
     ///
@@ -116,7 +116,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `responseObj`: The object to send back to the client.
+    /// `responseObj`: The object to send back to the client.
     ///
     /// **Output**
     ///
@@ -138,9 +138,9 @@ type HttpContext with
 ///
 /// **Parameters**
 ///
-/// - `negotiationRules`: A dictionary of mime types and response writing `HttpHandler` functions. Each mime type must be mapped to a function which accepts an `obj` and returns a `HttpHandler` which will send a response in the associated mime type (e.g.: `dict [ "application/json", json; "application/xml" , xml ]`).
-/// - `unacceptableHandler`: A `HttpHandler` function which will be invoked if none of the accepted mime types can be satisfied. Generally this `HttpHandler` would send a response with a status code of `406 Unacceptable`.
-/// - `responseObj`: The object to send back to the client.
+/// `negotiationRules`: A dictionary of mime types and response writing `HttpHandler` functions. Each mime type must be mapped to a function which accepts an `obj` and returns a `HttpHandler` which will send a response in the associated mime type (e.g.: `dict [ "application/json", json; "application/xml" , xml ]`).
+/// `unacceptableHandler`: A `HttpHandler` function which will be invoked if none of the accepted mime types can be satisfied. Generally this `HttpHandler` would send a response with a status code of `406 Unacceptable`.
+/// `responseObj`: The object to send back to the client.
 ///
 /// **Output**
 ///
@@ -161,7 +161,7 @@ let negotiateWith (negotiationRules    : IDictionary<string, obj -> HttpHandler>
 ///
 /// **Parameters**
 ///
-/// - `responseObj`: The object to send back to the client.
+/// `responseObj`: The object to send back to the client.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Preconditional.fs
+++ b/src/Giraffe/Preconditional.fs
@@ -23,8 +23,8 @@ type EntityTagHeaderValue with
     ///
     /// **Parameters**
     ///
-    /// - `isWeak`: The difference between a regular (strong) ETag and a weak ETag is that a matching strong ETag guarantees the file is byte-for-byte identical, whereas a matching weak ETag indicates that the content is semantically the same. So if the content of the file changes, the weak ETag should change as well.
-    /// - `eTag`: The entity tag value (without quotes or the `W/` prefix).
+    /// `isWeak`: The difference between a regular (strong) ETag and a weak ETag is that a matching strong ETag guarantees the file is byte-for-byte identical, whereas a matching weak ETag indicates that the content is semantically the same. So if the content of the file changes, the weak ETag should change as well.
+    /// `eTag`: The entity tag value (without quotes or the `W/` prefix).
     ///
     /// **Output**
     ///
@@ -98,24 +98,24 @@ type HttpContext with
     ///
     /// Validates the following conditional HTTP headers of the HTTP request:
     ///
-    /// - `If-Match`
-    /// - `If-None-Match`
-    /// - `If-Modified-Since`
-    /// - `If-Unmodified-Since`
+    /// `If-Match`
+    /// `If-None-Match`
+    /// `If-Modified-Since`
+    /// `If-Unmodified-Since`
     ///
     /// **Parameters**
     ///
-    /// - `eTag`: Optional ETag. You can use the static `EntityTagHeaderValue.FromString` helper method to generate a valid `EntityTagHeaderValue` object.
-    /// - `lastModified`: Optional `DateTimeOffset` object denoting the last modified date.
+    /// `eTag`: Optional ETag. You can use the static `EntityTagHeaderValue.FromString` helper method to generate a valid `EntityTagHeaderValue` object.
+    /// `lastModified`: Optional `DateTimeOffset` object denoting the last modified date.
     ///
     /// **Output**
     ///
     /// Returns a `Precondition` union type, which can have one of the following cases:
     ///
-    /// - `NoConditionsSpecified`: No validation has taken place, because the client didn't send any conditional HTTP headers.
-    /// - `ConditionFailed`: At least one condition couldn't be sastisfied. It is advised to return a `412` status code back to the client (you can use the `HttpContext.PreconditionFailedResponse()` method for that purpose).
-    /// - `ResourceNotModified`: The resource hasn't changed since the last visit. The server can skip processing this request and return a `304` status code back to the client (you can use the `HttpContext.NotModifiedResponse()` method for that purpose).
-    /// - `AllConditionsMet`: All pre-conditions can be satisfied. The server should continue processing the request as normal.
+    /// `NoConditionsSpecified`: No validation has taken place, because the client didn't send any conditional HTTP headers.
+    /// `ConditionFailed`: At least one condition couldn't be sastisfied. It is advised to return a `412` status code back to the client (you can use the `HttpContext.PreconditionFailedResponse()` method for that purpose).
+    /// `ResourceNotModified`: The resource hasn't changed since the last visit. The server can skip processing this request and return a `304` status code back to the client (you can use the `HttpContext.NotModifiedResponse()` method for that purpose).
+    /// `AllConditionsMet`: All pre-conditions can be satisfied. The server should continue processing the request as normal.
     ///
     member this.ValidatePreconditions (eTag : EntityTagHeaderValue option) (lastModified : DateTimeOffset option) =
         // Parse headers
@@ -173,17 +173,17 @@ type HttpContext with
 ///
 /// Validates the following conditional HTTP headers of the request:
 ///
-/// - `If-Match`
-/// - `If-None-Match`
-/// - `If-Modified-Since`
-/// - `If-Unmodified-Since`
+/// `If-Match`
+/// `If-None-Match`
+/// `If-Modified-Since`
+/// `If-Unmodified-Since`
 ///
 /// If the conditions are met (or non existent) then it will invoke the `next` http handler in the pipeline otherwise it will return a `304 Not Modified` or `412 Precondition Failed` response.
 ///
 /// **Parameters**
 ///
-/// - `eTag`: Optional ETag. You can use the static `EntityTagHeaderValue.FromString` helper method to generate a valid `EntityTagHeaderValue` object.
-/// - `lastModified`: Optional `DateTimeOffset` object denoting the last modified date.
+/// `eTag`: Optional ETag. You can use the static `EntityTagHeaderValue.FromString` helper method to generate a valid `EntityTagHeaderValue` object.
+/// `lastModified`: Optional `DateTimeOffset` object denoting the last modified date.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/ResponseCaching.fs
+++ b/src/Giraffe/ResponseCaching.fs
@@ -11,9 +11,9 @@ open Microsoft.AspNetCore.ResponseCaching
 ///
 /// Specifies the directive for the `Cache-Control` HTTP header:
 ///
-/// - `NoCache`: The resource should not be cached under any circumstances.
-/// - `Public`: Any client and proxy may cache the resource for the given amount of time.
-/// - `Private`: Only the end client may cache the resource for the given amount of time.
+/// `NoCache`: The resource should not be cached under any circumstances.
+/// `Public`: Any client and proxy may cache the resource for the given amount of time.
+/// `Private`: Only the end client may cache the resource for the given amount of time.
 ///
 type CacheDirective =
     | NoCache
@@ -36,9 +36,9 @@ let inline private cacheHeader isPublic duration =
 ///
 /// **Parameters**
 ///
-/// - `directive`: Specifies the cache directive to be set in the response's HTTP headers. Use `NoCache` to suppress caching altogether or use `Public`/`Private` to enable caching for everyone or clients only.
-/// - `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
-/// - `varyByQueryKeys`: An optional list of query keys which will be used by the ASP.NET Core response caching middleware to vary (potentially) cached responses. If this parameter is used then the ASP.NET Core response caching middleware has to be enabled. For more information check the official [VaryByQueryKeys](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/middleware?view=aspnetcore-2.1#varybyquerykeys) documentation.
+/// `directive`: Specifies the cache directive to be set in the response's HTTP headers. Use `NoCache` to suppress caching altogether or use `Public`/`Private` to enable caching for everyone or clients only.
+/// `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
+/// `varyByQueryKeys`: An optional list of query keys which will be used by the ASP.NET Core response caching middleware to vary (potentially) cached responses. If this parameter is used then the ASP.NET Core response caching middleware has to be enabled. For more information check the official [VaryByQueryKeys](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/middleware?view=aspnetcore-2.1#varybyquerykeys) documentation.
 ///
 /// **Output**
 ///
@@ -88,8 +88,8 @@ let noResponseCaching : HttpHandler = responseCaching NoCache None None
 ///
 /// **Parameters**
 ///
-/// - `seconds`: Specifies the duration (in seconds) for which the response may be cached.
-/// - `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
+/// `seconds`: Specifies the duration (in seconds) for which the response may be cached.
+/// `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
 ///
 /// **Output**
 ///
@@ -106,8 +106,8 @@ let privateResponseCaching (seconds : int) (vary : string option) : HttpHandler 
 ///
 /// **Parameters**
 ///
-/// - `seconds`: Specifies the duration (in seconds) for which the response may be cached.
-/// - `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
+/// `seconds`: Specifies the duration (in seconds) for which the response may be cached.
+/// `vary`: Optionally specify which HTTP headers have to match in order to return a cached response (e.g. `Accept` and/or `Accept-Encoding`).
 ///
 /// **Output**
 ///

--- a/src/Giraffe/ResponseWriters.fs
+++ b/src/Giraffe/ResponseWriters.fs
@@ -70,7 +70,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `bytes`: The byte array to be send back to the client.
+    /// `bytes`: The byte array to be send back to the client.
     ///
     /// **Output**
     ///
@@ -90,7 +90,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `str`: The string value to be send back to the client.
+    /// `str`: The string value to be send back to the client.
     ///
     /// **Output**
     ///
@@ -105,7 +105,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `str`: The string value to be send back to the client.
+    /// `str`: The string value to be send back to the client.
     ///
     /// **Output**
     ///
@@ -125,7 +125,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `dataObj`: The object to be send back to the client.
+    /// `dataObj`: The object to be send back to the client.
     ///
     /// **Output**
     ///
@@ -147,7 +147,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `dataObj`: The object to be send back to the client.
+    /// `dataObj`: The object to be send back to the client.
     ///
     /// **Output**
     ///
@@ -173,7 +173,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `dataObj`: The object to be send back to the client.
+    /// `dataObj`: The object to be send back to the client.
     ///
     /// **Output**
     ///
@@ -193,7 +193,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `filePath`: A relative or absolute file path to the HTML file.
+    /// `filePath`: A relative or absolute file path to the HTML file.
     ///
     /// **Output**
     ///
@@ -220,7 +220,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `html`: The HTML string to be send back to the client.
+    /// `html`: The HTML string to be send back to the client.
     ///
     /// **Output**
     ///
@@ -238,7 +238,7 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `htmlView`: An `XmlNode` object to be send back to the client and which represents a valid HTML view.
+    /// `htmlView`: An `XmlNode` object to be send back to the client and which represents a valid HTML view.
     ///
     /// **Output**
     ///
@@ -259,7 +259,7 @@ type HttpContext with
 ///
 /// **Parameters**
 ///
-/// - `bytes`: The byte array to be send back to the client.
+/// `bytes`: The byte array to be send back to the client.
 ///
 /// **Output**
 ///
@@ -275,7 +275,7 @@ let setBody (bytes : byte array) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `str`: The string value to be send back to the client.
+/// `str`: The string value to be send back to the client.
 ///
 /// **Output**
 ///
@@ -292,7 +292,7 @@ let setBodyFromString (str : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `str`: The string value to be send back to the client.
+/// `str`: The string value to be send back to the client.
 ///
 /// **Output**
 ///
@@ -314,7 +314,7 @@ let text (str : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `dataObj`: The object to be send back to the client.
+/// `dataObj`: The object to be send back to the client.
 ///
 /// **Output**
 ///
@@ -334,7 +334,7 @@ let json<'T> (dataObj : 'T) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `dataObj`: The object to be send back to the client.
+/// `dataObj`: The object to be send back to the client.
 ///
 /// **Output**
 ///
@@ -354,7 +354,7 @@ let jsonChunked<'T> (dataObj : 'T) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `dataObj`: The object to be send back to the client.
+/// `dataObj`: The object to be send back to the client.
 ///
 /// **Output**
 ///
@@ -372,7 +372,7 @@ let xml (dataObj : obj) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `filePath`: A relative or absolute file path to the HTML file.
+/// `filePath`: A relative or absolute file path to the HTML file.
 ///
 /// **Output**
 ///
@@ -390,7 +390,7 @@ let htmlFile (filePath : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `html`: The HTML string to be send back to the client.
+/// `html`: The HTML string to be send back to the client.
 ///
 /// **Output**
 ///
@@ -410,7 +410,7 @@ let htmlString (html : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `htmlView`: An `XmlNode` object to be send back to the client and which represents a valid HTML view.
+/// `htmlView`: An `XmlNode` object to be send back to the client and which represents a valid HTML view.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Routing.fs
+++ b/src/Giraffe/Routing.fs
@@ -54,7 +54,7 @@ module SubRouting =
 ///
 /// **Parameters**
 ///
-/// - `fns`: List of port to `HttpHandler` mappings
+/// `fns`: List of port to `HttpHandler` mappings
 ///
 /// **Output**
 ///
@@ -78,7 +78,7 @@ let routePorts (fns : (int * HttpHandler) list) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: Request path.
+/// `path`: Request path.
 ///
 /// **Output**
 ///
@@ -96,7 +96,7 @@ let route (path : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: Request path.
+/// `path`: Request path.
 ///
 /// **Output**
 ///
@@ -114,7 +114,7 @@ let routeCi (path : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: Regex path.
+/// `path`: Regex path.
 ///
 /// **Output**
 ///
@@ -135,7 +135,7 @@ let routex (path : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: Regex path.
+/// `path`: Regex path.
 ///
 /// **Output**
 ///
@@ -158,18 +158,18 @@ let routeCix (path : string) : HttpHandler =
 ///
 /// **Supported format chars**
 ///
-/// - `%b`: `bool`
-/// - `%c`: `char`
-/// - `%s`: `string`
-/// - `%i`: `int`
-/// - `%d`: `int64`
-/// - `%f`: `float`/`double`
-/// - `%O`: `Guid`
+/// `%b`: `bool`
+/// `%c`: `char`
+/// `%s`: `string`
+/// `%i`: `int`
+/// `%d`: `int64`
+/// `%f`: `float`/`double`
+/// `%O`: `Guid`
 ///
 /// **Parameters**
 ///
-/// - `path`: A format string representing the expected request path.
-/// - `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
+/// `path`: A format string representing the expected request path.
+/// `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
 ///
 /// **Output**
 ///
@@ -191,18 +191,18 @@ let routef (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandler)
 ///
 /// **Supported format chars**
 ///
-/// - `%b`: `bool`
-/// - `%c`: `char`
-/// - `%s`: `string`
-/// - `%i`: `int`
-/// - `%d`: `int64`
-/// - `%f`: `float`/`double`
-/// - `%O`: `Guid`
+/// `%b`: `bool`
+/// `%c`: `char`
+/// `%s`: `string`
+/// `%i`: `int`
+/// `%d`: `int64`
+/// `%f`: `float`/`double`
+/// `%O`: `Guid`
 ///
 /// **Parameters**
 ///
-/// - `path`: A format string representing the expected request path.
-/// - `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
+/// `path`: A format string representing the expected request path.
+/// `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
 ///
 /// **Output**
 ///
@@ -224,8 +224,8 @@ let routeCif (path : PrintfFormat<_,_,_,_, 'T>) (routeHandler : 'T -> HttpHandle
 ///
 /// **Parameters**
 ///
-/// - `route`: A string representing the expected request path. Use `{propertyName}` for reserved parameter names which should map to the properties of type `'T`. You can also use valid `Regex` within the `route` string.
-/// - `routeHandler`: A function which accepts a tuple `'T` of the parsed parameters and returns a `HttpHandler` function which will subsequently deal with the request.
+/// `route`: A string representing the expected request path. Use `{propertyName}` for reserved parameter names which should map to the properties of type `'T`. You can also use valid `Regex` within the `route` string.
+/// `routeHandler`: A function which accepts a tuple `'T` of the parsed parameters and returns a `HttpHandler` function which will subsequently deal with the request.
 ///
 /// **Output**
 ///
@@ -256,7 +256,7 @@ let routeBind<'T> (route : string) (routeHandler : 'T -> HttpHandler) : HttpHand
 ///
 /// **Parameters**
 ///
-/// - `subPath`: The expected beginning of a request path.
+/// `subPath`: The expected beginning of a request path.
 ///
 /// **Output**
 ///
@@ -274,7 +274,7 @@ let routeStartsWith (subPath : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `subPath`: The expected beginning of a request path.
+/// `subPath`: The expected beginning of a request path.
 ///
 /// **Output**
 ///
@@ -294,7 +294,7 @@ let routeStartsWithCi (subPath : string) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: A part of an expected request path.
+/// `path`: A part of an expected request path.
 ///
 /// **Output**
 ///
@@ -312,7 +312,7 @@ let subRoute (path : string) (handler : HttpHandler) : HttpHandler =
 ///
 /// **Parameters**
 ///
-/// - `path`: A part of an expected request path.
+/// `path`: A part of an expected request path.
 ///
 /// **Output**
 ///
@@ -330,20 +330,20 @@ let subRouteCi (path : string) (handler : HttpHandler) : HttpHandler =
 ///
 /// **Supported format chars**
 ///
-/// - `%b`: `bool`
-/// - `%c`: `char`
-/// - `%s`: `string`
-/// - `%i`: `int`
-/// - `%d`: `int64`
-/// - `%f`: `float`/`double`
-/// - `%O`: `Guid`
+/// `%b`: `bool`
+/// `%c`: `char`
+/// `%s`: `string`
+/// `%i`: `int`
+/// `%d`: `int64`
+/// `%f`: `float`/`double`
+/// `%O`: `Guid`
 ///
 /// Subsequent routing handlers inside the given `handler` function should omit the already validated path.
 ///
 /// **Parameters**
 ///
-/// - `path`: A format string representing the expected request sub path.
-/// - `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
+/// `path`: A format string representing the expected request sub path.
+/// `routeHandler`: A function which accepts a tuple `'T` of the parsed arguments and returns a `HttpHandler` function which will subsequently deal with the request.
 ///
 /// **Output**
 ///

--- a/src/Giraffe/Streaming.fs
+++ b/src/Giraffe/Streaming.fs
@@ -158,10 +158,10 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
-    /// - `stream`: The stream to be send to the client.
-    /// - `eTag`: An optional entity tag which identifies the exact version of the data.
-    /// - `lastModified`: An optional parameter denoting the last modifed date time of the data.
+    /// `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
+    /// `stream`: The stream to be send to the client.
+    /// `eTag`: An optional entity tag which identifies the exact version of the data.
+    /// `lastModified`: An optional parameter denoting the last modifed date time of the data.
     ///
     /// **Output**
     ///
@@ -208,10 +208,10 @@ type HttpContext with
     ///
     /// **Parameters**
     ///
-    /// - `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
-    /// - `filePath`: The absolute or relative path (to `ContentRoot`) of the file.
-    /// - `eTag`: An optional entity tag which identifies the exact version of the file.
-    /// - `lastModified`: An optional parameter denoting the last modifed date time of the file.
+    /// `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
+    /// `filePath`: The absolute or relative path (to `ContentRoot`) of the file.
+    /// `eTag`: An optional entity tag which identifies the exact version of the file.
+    /// `lastModified`: An optional parameter denoting the last modifed date time of the file.
     ///
     /// **Output**
     ///
@@ -244,10 +244,10 @@ type HttpContext with
 ///
 /// **Parameters**
 ///
-/// - `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
-/// - `stream`: The stream to be send to the client.
-/// - `eTag`: An optional entity tag which identifies the exact version of the data.
-/// - `lastModified`: An optional parameter denoting the last modifed date time of the file.
+/// `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
+/// `stream`: The stream to be send to the client.
+/// `eTag`: An optional entity tag which identifies the exact version of the data.
+/// `lastModified`: An optional parameter denoting the last modifed date time of the file.
 ///
 /// **Output**
 ///
@@ -269,10 +269,10 @@ let streamData (enableRangeProcessing : bool)
 ///
 /// **Parameters**
 ///
-/// - `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
-/// - `filePath`: The absolute or relative path (to `ContentRoot`) of the file.
-/// - `eTag`: An optional entity tag which identifies the exact version of the file.
-/// - `lastModified`: An optional parameter denoting the last modifed date time of the file.
+/// `enableRangeProcessing`: If enabled then the handler will respect the `Range` and `If-Range` HTTP headers of the request as well as set all necessary HTTP headers in the response to enable HTTP range processing.
+/// `filePath`: The absolute or relative path (to `ContentRoot`) of the file.
+/// `eTag`: An optional entity tag which identifies the exact version of the file.
+/// `lastModified`: An optional parameter denoting the last modifed date time of the file.
 ///
 /// **Output**
 ///


### PR DESCRIPTION
As discussed in #329,  this PR adds asynchronous counter parts for `handleContext` and `handleRequest` along with their docs and release notes. 

### Example use case
```fs
let echoContents (request: HttpRequest) = 
  task {
      use reader = new StreamReader(request.Body)
      let! contents = reader.ReadToEndAsync()
      return text contents 
  }

let webApp = POST >=> route "/echo" >=> handleRequestAsync echoContents
```