### PR TITLE
Support array of generic type as a child in form binding

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,10 @@ Match: false
 
 For more information please see [issue #347](https://github.com/giraffe-fsharp/Giraffe/issues/347).
 
+#### New features
+
+- Support array of 'T as a child in form binding
+
 #### Bug fixes and breaking changes
 
 - Fixed `routef` to not match more than one URL path segment.

--- a/src/Giraffe/ModelBinding.fs
+++ b/src/Giraffe/ModelBinding.fs
@@ -198,11 +198,12 @@ module ModelParser =
                     
                     index, key, value
                 )
-                |> Seq.groupBy (fun (index, _, _) -> index)
+                |> Seq.groupBy (fun (index, _, _) -> index |> int)
+                |> Seq.sortBy (fun (index, _) -> index)
                 |> Seq.choose (fun (index, values) ->
                     let dictData =
                         values
-                        |> Seq.fold(fun (state : Map<string, StringValues>) (index, key, value) ->
+                        |> Seq.fold(fun (state : Map<string, StringValues>) (_, key, value) ->
                             state.Add(key, value)
                         ) Map.empty
                     
@@ -211,7 +212,7 @@ module ModelParser =
                                         
                     match res with
                     | Ok o ->
-                        Some(index |> int, o)
+                        Some(index, o)
                     | Error _ -> None
                 )
             

--- a/src/Giraffe/ModelBinding.fs
+++ b/src/Giraffe/ModelBinding.fs
@@ -13,6 +13,7 @@ open Microsoft.Extensions.Primitives
 open Microsoft.Net.Http.Headers
 open Microsoft.FSharp.Reflection
 open FSharp.Control.Tasks.V2.ContextInsensitive
+open System.Text.RegularExpressions
 
 // ---------------------------
 // Model parsing functions
@@ -112,10 +113,11 @@ module ModelParser =
                 sprintf "Could not parse value '%s' to type %s." rawValue (t.ToString())
                 |> Error
 
-    let private parseModel<'T> (cultureInfo : CultureInfo option)
-                               (data        : IDictionary<string, StringValues>)
-                               (strict      : bool)
-                               : Result<'T, string> =
+    let rec private parseModel<'T> (model       : 'T)
+                                   (cultureInfo : CultureInfo option)
+                                   (data        : IDictionary<string, StringValues>)
+                                   (strict      : bool)
+                                   : Result<'T, string> =
         // Normalize data
         let normalizeKey (key : string) =
             key.ToLowerInvariant().TrimEnd([| '['; ']' |])
@@ -126,8 +128,7 @@ module ModelParser =
 
         // Create culture and model objects
         let culture = defaultArg cultureInfo CultureInfo.InvariantCulture
-        let model   = Activator.CreateInstance<'T>()
-
+        
         let error =
             // Iterate through all properties of the model
             model.GetType().GetProperties(BindingFlags.Instance ||| BindingFlags.Public)
@@ -146,9 +147,12 @@ module ModelParser =
                             // If there was an entry then try to parse the raw value.
                             match data.TryGetValue (prop.Name.ToLowerInvariant()) with
                             | false, _        ->
-                                match getValueForMissingProperty prop.PropertyType with
+                                match getValueForArrayOfGenericType cultureInfo data strict prop with
                                 | Some v -> Ok v
-                                | None   -> Error (sprintf "Missing value for required property %s." prop.Name)
+                                | None ->
+                                    match getValueForMissingProperty prop.PropertyType with
+                                    | Some v -> Ok v
+                                    | None   -> Error (sprintf "Missing value for required property %s." prop.Name)
                             | true , rawValue -> parseValue prop.PropertyType rawValue culture
 
                         // Check if a value was able to get successfully parsed.
@@ -169,6 +173,63 @@ module ModelParser =
         match strict, error with
         | true, Some err -> Error err
         | _   , _        -> Ok model
+        
+    and getValueForArrayOfGenericType (cultureInfo : CultureInfo option)
+                                      (data        : IDictionary<string, StringValues>)
+                                      (strict      : bool)
+                                      (prop        : PropertyInfo)
+                                      : (obj option) =
+
+        if prop.PropertyType.IsArray then
+            let lowerCasedPropName = prop.Name.ToLowerInvariant()
+            let pattern = lowerCasedPropName |> Regex.Escape |> sprintf @"%s\[(\d+)\]\.(\w+)"
+            
+            let innerType = prop.PropertyType.GetElementType()
+                        
+            let seqOfObjects = 
+                data
+                |> Seq.filter (fun item -> Regex.IsMatch(item.Key, pattern))
+                |> Seq.map (fun item ->
+                    let matchedData = Regex.Match(item.Key, pattern)
+                    
+                    let index = matchedData.Groups.[1].Value
+                    let key = matchedData.Groups.[2].Value
+                    let value = item.Value
+                    
+                    index, key, value
+                )
+                |> Seq.groupBy (fun (index, _, _) -> index)
+                |> Seq.choose (fun (index, values) ->
+                    let dictData =
+                        values
+                        |> Seq.fold(fun (state : Map<string, StringValues>) (index, key, value) ->
+                            state.Add(key, value)
+                        ) Map.empty
+                    
+                    let model = Activator.CreateInstance(innerType)
+                    let res = parseModel model cultureInfo dictData strict
+                                        
+                    match res with
+                    | Ok o ->
+                        Some(index |> int, o)
+                    | Error _ -> None
+                )
+            
+            let arrayOfObjects =
+                if (seqOfObjects |> Seq.length > 0) then    
+                    let arraySize = (seqOfObjects |> Seq.last |> fst) + 1
+                    let arrayOfObjects = Array.CreateInstance(innerType, arraySize)
+                                 
+                    seqOfObjects
+                    |> Seq.iter (fun (index, item) -> arrayOfObjects.SetValue(item, index))
+                    
+                    arrayOfObjects
+                else
+                    Array.CreateInstance(innerType, 0)
+            
+            arrayOfObjects |> box |> Some
+        else
+            None
 
     /// **Description**
     ///
@@ -187,7 +248,9 @@ module ModelParser =
     ///
     let tryParse<'T> (culture : CultureInfo option)
                      (data    : IDictionary<string, StringValues>) =
-        parseModel<'T> culture data true
+        let model = Activator.CreateInstance<'T>()
+
+        parseModel<'T> model culture data true
 
     /// **Description**
     ///
@@ -206,7 +269,9 @@ module ModelParser =
     ///
     let parse<'T> (culture : CultureInfo option)
                   (data    : IDictionary<string, StringValues>) =
-        let result = parseModel<'T> culture data false
+        let model = Activator.CreateInstance<'T>()
+        
+        let result = parseModel<'T> model culture data false
         match result with
         | Ok model  -> model
         | Error msg -> failwithf "Unexpected error during non-strict model parsing: %s" msg

--- a/tests/Giraffe.Tests/ModelBindingTests.fs
+++ b/tests/Giraffe.Tests/ModelBindingTests.fs
@@ -12,7 +12,6 @@ open Microsoft.Extensions.Primitives
 open FSharp.Control.Tasks.V2.ContextInsensitive
 open Xunit
 open NSubstitute
-open Newtonsoft.Json
 open Giraffe
 
 [<CLIMutable>]
@@ -513,10 +512,6 @@ let ``ModelParser.parse with incomplete model data`` () =
             "Children[2].Age"  , StringValues "44"
         ]
     
-    let arrayOfChildren = Array.CreateInstance(typeof<Child>, 3)
-    arrayOfChildren.SetValue({ Name = "Hamed"; Age = 0 }, 0)
-    arrayOfChildren.SetValue({ Name = null; Age = 44 }, 2)
-
     let expected =
         {
             Id         = Guid.Empty
@@ -526,7 +521,11 @@ let ``ModelParser.parse with incomplete model data`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
-            Children   = arrayOfChildren :?> Child[]
+            Children   = [|
+                { Name = "Hamed"; Age = 0 }
+                Unchecked.defaultof<_>
+                { Name = null; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -544,10 +543,6 @@ let ``ModelParser.parse with incomplete model data and with different order for 
             "Children[2].Age"  , StringValues "44"
             "Children[0].Name" , StringValues "Hamed"
         ]
-    
-    let arrayOfChildren = Array.CreateInstance(typeof<Child>, 3)
-    arrayOfChildren.SetValue({ Name = "Hamed"; Age = 0 }, 0)
-    arrayOfChildren.SetValue({ Name = null; Age = 44 }, 2)
 
     let expected =
         {
@@ -558,7 +553,11 @@ let ``ModelParser.parse with incomplete model data and with different order for 
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
-            Children   = arrayOfChildren :?> Child[]
+            Children   = [|
+                { Name = "Hamed"; Age = 0 }
+                Unchecked.defaultof<_>
+                { Name = null; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -576,11 +575,7 @@ let ``ModelParser.parse with incomplete model data and wrong union case`` () =
             "Children[0].Name" , StringValues "Hamed"
             "Children[2].Age"  , StringValues "44"
         ]
-    
-    let arrayOfChildren = Array.CreateInstance(typeof<Child>, 3)
-    arrayOfChildren.SetValue({ Name = "Hamed"; Age = 0 }, 0)
-    arrayOfChildren.SetValue({ Name = null; Age = 44 }, 2)
-        
+
     let expected =
         {
             Id         = Guid.Empty
@@ -590,7 +585,11 @@ let ``ModelParser.parse with incomplete model data and wrong union case`` () =
             Sex        = Unchecked.defaultof<Sex>
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
-            Children   = arrayOfChildren :?> Child[]
+            Children   = [|
+                { Name = "Hamed"; Age = 0 }
+                Unchecked.defaultof<_>
+                { Name = null; Age = 44 }
+            |]
         }
         
     let culture = None

--- a/tests/Giraffe.Tests/ModelBindingTests.fs
+++ b/tests/Giraffe.Tests/ModelBindingTests.fs
@@ -51,6 +51,13 @@ type Sex =
     | Female
 
 [<CLIMutable>]
+type Child =
+    {
+        Name : string
+        Age  : int
+    }
+    
+[<CLIMutable>]
 type Model =
     {
         Id         : Guid
@@ -60,6 +67,7 @@ type Model =
         Sex        : Sex
         BirthDate  : DateTime
         Nicknames  : string list option
+        Children   : Child[]
     }
 
 [<CLIMutable>]
@@ -98,13 +106,19 @@ let ``ModelParser.tryParse with complete model data`` () =
     let id = Guid.NewGuid()
     let modelData =
         dict [
-            "Id"        , StringValues (id.ToString())
-            "FirstName" , StringValues "Susan"
-            "MiddleName", StringValues "Elisabeth"
-            "LastName"  , StringValues "Doe"
-            "Sex"       , StringValues "Female"
-            "BirthDate" , StringValues "1986-12-29"
-            "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Id"               , StringValues (id.ToString())
+            "FirstName"        , StringValues "Susan"
+            "MiddleName"       , StringValues "Elisabeth"
+            "LastName"         , StringValues "Doe"
+            "Sex"              , StringValues "Female"
+            "BirthDate"        , StringValues "1986-12-29"
+            "Nicknames"        , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "44"
         ]
     let expected =
         {
@@ -115,8 +129,14 @@ let ``ModelParser.tryParse with complete model data`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
+    
     let result = ModelParser.tryParse<Model> culture modelData
     match result with
     | Ok model  -> Assert.Equal(expected, model)
@@ -132,6 +152,12 @@ let ``ModelParser.tryParse with model data without optional parameters`` () =
             "LastName"  , StringValues "Doe"
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "1986-12-29"
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "44"
         ]
     let expected =
         {
@@ -142,6 +168,11 @@ let ``ModelParser.tryParse with model data without optional parameters`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = None
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.tryParse<Model> culture modelData
@@ -161,6 +192,12 @@ let ``ModelParser.tryParse with complete model data but mixed casing`` () =
             "Sex"       , StringValues "female"
             "BirthDate" , StringValues "1986-12-29"
             "NickNames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].name" , StringValues "Ali"
+            "children[1].Age"  , StringValues "22"
+            "children[2].Name" , StringValues "Gholi"
+            "children[2].age"  , StringValues "44"
         ]
     let expected =
         {
@@ -171,6 +208,11 @@ let ``ModelParser.tryParse with complete model data but mixed casing`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.tryParse<Model> culture modelData
@@ -187,6 +229,8 @@ let ``ModelParser.tryParse with incomplete model data`` () =
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "1986-12-29"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[2].Age"  , StringValues "44"
         ]
     let culture = None
     let result = ModelParser.tryParse<Model> culture modelData
@@ -206,6 +250,12 @@ let ``ModelParser.tryParse with complete model data but wrong union case`` () =
             "Sex"       , StringValues "wrong"
             "BirthDate" , StringValues "1986-12-29"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "44"
         ]
     let culture = None
     let result = ModelParser.tryParse<Model> culture modelData
@@ -225,6 +275,12 @@ let ``ModelParser.tryParse with complete model data but wrong data`` () =
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "wrong"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "wrongAge"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "wrongAge"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "wrongAge"
         ]
     let culture = None
     let result = ModelParser.tryParse<Model> culture modelData
@@ -248,6 +304,12 @@ let ``ModelParser.parse with complete model data`` () =
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "1986-12-29"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "44"
         ]
     let expected =
         {
@@ -258,6 +320,11 @@ let ``ModelParser.parse with complete model data`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -273,6 +340,12 @@ let ``ModelParser.parse with model data without optional parameters`` () =
             "LastName"  , StringValues "Doe"
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "1986-12-29"
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "44"
         ]
     let expected =
         {
@@ -283,6 +356,11 @@ let ``ModelParser.parse with model data without optional parameters`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = None
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -300,6 +378,12 @@ let ``ModelParser.parse with complete model data but mixed casing`` () =
             "Sex"       , StringValues "female"
             "BirthDate" , StringValues "1986-12-29"
             "NickNames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "32"
+            "Children[1].name" , StringValues "Ali"
+            "children[1].Age"  , StringValues "22"
+            "children[2].Name" , StringValues "Gholi"
+            "children[2].age"  , StringValues "44"
         ]
     let expected =
         {
@@ -310,6 +394,11 @@ let ``ModelParser.parse with complete model data but mixed casing`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = [|
+                { Name = "Hamed"; Age = 32 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 44 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -324,7 +413,14 @@ let ``ModelParser.parse with incomplete model data`` () =
             "Sex"       , StringValues "Female"
             "BirthDate" , StringValues "1986-12-29"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[2].Age"  , StringValues "44"
         ]
+    
+    let arrayOfChildren = Array.CreateInstance(typeof<Child>, 3)
+    arrayOfChildren.SetValue({ Name = "Hamed"; Age = 0 }, 0)
+    arrayOfChildren.SetValue({ Name = null; Age = 44 }, 2)
+
     let expected =
         {
             Id         = Guid.Empty
@@ -334,6 +430,7 @@ let ``ModelParser.parse with incomplete model data`` () =
             Sex        = Female
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = arrayOfChildren :?> Child[]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -348,7 +445,14 @@ let ``ModelParser.parse with incomplete model data and wrong union case`` () =
             "Sex"       , StringValues "wrong"
             "BirthDate" , StringValues "1986-12-29"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[2].Age"  , StringValues "44"
         ]
+    
+    let arrayOfChildren = Array.CreateInstance(typeof<Child>, 3)
+    arrayOfChildren.SetValue({ Name = "Hamed"; Age = 0 }, 0)
+    arrayOfChildren.SetValue({ Name = null; Age = 44 }, 2)
+        
     let expected =
         {
             Id         = Guid.Empty
@@ -358,9 +462,12 @@ let ``ModelParser.parse with incomplete model data and wrong union case`` () =
             Sex        = Unchecked.defaultof<Sex>
             BirthDate  = DateTime(1986, 12, 29)
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = arrayOfChildren :?> Child[]
         }
+        
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
+    
     Assert.Equal(expected.Id, result.Id)
     Assert.Equal(expected.FirstName, result.FirstName)
     Assert.Equal(expected.MiddleName, result.MiddleName)
@@ -368,6 +475,7 @@ let ``ModelParser.parse with incomplete model data and wrong union case`` () =
     Assert.Null(result.Sex)
     Assert.Equal(expected.BirthDate, result.BirthDate)
     Assert.Equal(expected.Nicknames, result.Nicknames)
+    Assert.Equal<Child[]>(expected.Children, result.Children)
 
 [<Fact>]
 let ``ModelParser.parse with complete model data but wrong data`` () =
@@ -378,6 +486,12 @@ let ``ModelParser.parse with complete model data but wrong data`` () =
             "Sex"       , StringValues "wrong"
             "BirthDate" , StringValues "wrong"
             "Nicknames" , StringValues [| "Susi"; "Eli"; "Liz" |]
+            "Children[0].Name" , StringValues "Hamed"
+            "Children[0].Age"  , StringValues "wrongAge"
+            "Children[1].Name" , StringValues "Ali"
+            "Children[1].Age"  , StringValues "22"
+            "Children[2].Name" , StringValues "Gholi"
+            "Children[2].Age"  , StringValues "wrongAge"
         ]
     let expected =
         {
@@ -388,6 +502,11 @@ let ``ModelParser.parse with complete model data but wrong data`` () =
             Sex        = Unchecked.defaultof<Sex>
             BirthDate  = Unchecked.defaultof<DateTime>
             Nicknames  = Some [ "Susi"; "Eli"; "Liz" ]
+            Children   = [|
+                { Name = "Hamed"; Age = 0 }
+                { Name = "Ali";   Age = 22 }
+                { Name = "Gholi"; Age = 0 }
+            |]
         }
     let culture = None
     let result = ModelParser.parse<Model> culture modelData
@@ -398,6 +517,7 @@ let ``ModelParser.parse with complete model data but wrong data`` () =
     Assert.Null(result.Sex)
     Assert.Equal(expected.BirthDate, DateTime.MinValue)
     Assert.Equal(expected.Nicknames, result.Nicknames)
+    Assert.Equal<Child[]>(expected.Children, result.Children)
 
 // ---------------------------------
 // TryBindQueryString Tests


### PR DESCRIPTION
Support array of 'T as a child in form binding. This PR addresses #349 issue[1].

[1]: After this PR got merged, I'll work on adding support of `seq` and `List` as a child in form binding.