### PR TITLE
Lower Json.NET version requirement to 11.0.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ For more information please see [issue #347](https://github.com/giraffe-fsharp/G
 - Fixed `routef` to not match more than one URL path segment.
 - Fixed the `_ariaLabelledBy` attribute in the `GiraffeViewEngine`
 - Fixed case insensitive route handlers on Ubuntu
+- Changed minimum version of `Newtonsoft.Json` to `11.0.2`. This allows Giraffe to be compatable with Azure Functions.  
 
 ## 3.6.0
 

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="2.2.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Utf8Json" Version="1.3.*" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #350

I am struggling to use Giraffe with Azure Functions, and there appears to be no downside to this. It appears that aspnetcore mvc indirectly targets 11.0.2, like azure functions and a lot of Microsoft packages.

We could target 9.x, however it feels appropriate to target 11.x as that is the earliest version to support netstandard2.0, and 11.0.2 has an F# relevant fix: "Fix - Fixed serializing F# enums".

I'm hoping we can get this into a 4.0.0 release?