### PR TITLE
Move some dependences to not be used on netcoreapp3.0.

### DIFF
--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Giraffe</AssemblyName>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Description>A native functional ASP.NET Core web framework for F# developers.</Description>
     <Copyright>Copyright 2018 Dustin Moris Gorski</Copyright>
     <Authors>Dustin Moris Gorski and contributors</Authors>
@@ -53,18 +53,18 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.*" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="2.2.*" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.*" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.*" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR will help generate significantly smaller dependencies for clients with Paket that use netcore3.