### PR TITLE
Raise NETStandard.Library version to 2.0.3

### DIFF
--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -56,6 +56,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Until TaskBuilder.fs targets ns2.0 we'll lift NETStandard.Library to avoid legacy cruft -->
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />


### PR DESCRIPTION
Relates to discussion in #398

With the sample app, the `project.assets.json` file (a sort of transient `paket.lock` for nuget) drops from `4830` lines vs `1300` lines.

A downside to this is:
- It's weird to have to do this
- We get a compiler warning in the Giraffe project that is hard to suppress

I'm not convinced we should merge this, I think the real solution is to press on with a `2.2.0` `TaskBuilder.fs`, or migrate to `ply`.