### PR TITLE
Clarify file upload streaming

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2087,7 +2087,7 @@ let fileUploadHandler =
 let webApp = route "/upload" >=> fileUploadHandler
 ```
 
-For large file uploads it is recommended to [stream the file](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads#uploading-large-files-with-streaming) in order to prevent resource exhaustion.
+The latter allows you to stream the file, which is [recommended for large file uploads](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads#uploading-large-files-with-streaming) in order to prevent resource exhaustion.
 
 See also [large file uploads in ASP.NET Core](https://stackoverflow.com/questions/36437282/dealing-with-large-file-uploads-on-asp-net-core-1-0) on StackOverflow.
 


### PR DESCRIPTION
Note: Please only merge if this is actually correct.

When I read the Giraffe docs, I didn't understand that you can stream files with the `IFormFeature` method. I thought the docs mentioned two different buffering upload mechanisms, and then referred to the oh-my-gosh-that's-a-lot-of-boilerplate streaming code shown in the linked MS docs (which do not mention `IFormFeature`) for streaming. But I then came across https://github.com/giraffe-fsharp/Giraffe/issues/48#issuecomment-302924969, and my understanding is now that the `IFormFeature` method is a low-boilerplate way to stream files.