### PR TITLE
Update README.md - Sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ open System
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
@@ -102,7 +103,7 @@ type Startup() =
         services.AddGiraffe() |> ignore
 
     member __.Configure (app : IApplicationBuilder)
-                        (env : IHostingEnvironment)
+                        (env : IHostEnvironment)
                         (loggerFactory : ILoggerFactory) =
         // Add Giraffe to the ASP.NET Core pipeline
         app.UseGiraffe webApp


### PR DESCRIPTION
Current sample code does not build on latest SDK (see below). Here is updated version.

```
dotnet build
Microsoft (R) Build Engine version 16.8.0+126527ff1 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored Credo.fsproj (in 319 ms).
Program.fs(19,32): warning FS0044: This construct is deprecated. This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment. [Credo.fsproj]
Program.fs(20,42): error FS0039: The type 'ILoggerFactory' is not defined. [Credo.fsproj]
Program.fs(19,32): warning FS0044: This construct is deprecated. This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment. [Credo.fsproj]
Program.fs(20,42): error FS0039: The type 'ILoggerFactory' is not defined. [Credo.fsproj]

Build FAILED.
```