### PR TITLE
Improve RecyclableMemoryStream usage

### DIFF
--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.*" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="[1.3.0,3.0)" />
     <PackageReference Include="System.Text.Json" Version="5.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
     <PackageReference Include="Utf8Json" Version="1.3.*" />

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="[1.3.0,3.0)" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
     <PackageReference Include="Utf8Json" Version="1.3.*" />

--- a/src/Giraffe/Helpers.fs
+++ b/src/Giraffe/Helpers.fs
@@ -4,6 +4,10 @@ namespace Giraffe
 module Helpers =
     open System
     open System.IO
+    open Microsoft.IO
+
+    /// <summary>Default single RecyclableMemoryStreamManager.</summary>
+    let recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>()
 
     /// <summary>
     /// Checks if an object is not null.

--- a/src/Giraffe/Json.fs
+++ b/src/Giraffe/Json.fs
@@ -36,6 +36,10 @@ module NewtonsoftJson =
         let serializer = JsonSerializer.Create settings
         let utf8EncodingWithoutBom = UTF8Encoding(false)
 
+        new(settings : JsonSerializerSettings) = Serializer(
+            settings,
+            recyclableMemoryStreamManager.Value)
+
         static member DefaultSettings =
             JsonSerializerSettings(
                 ContractResolver = CamelCasePropertyNamesContractResolver())
@@ -50,7 +54,7 @@ module NewtonsoftJson =
 
             member __.SerializeToStreamAsync (x : 'T) (stream : Stream) =
                 task {
-                    use memoryStream = rmsManager.GetStream()
+                    use memoryStream = rmsManager.GetStream("giraffe-json-serialize-to-stream")
                     use streamWriter = new StreamWriter(memoryStream, utf8EncodingWithoutBom)
                     use jsonTextWriter = new JsonTextWriter(streamWriter)
                     serializer.Serialize(jsonTextWriter, x)
@@ -68,7 +72,7 @@ module NewtonsoftJson =
 
             member __.DeserializeAsync<'T> (stream : Stream) =
                 task {
-                    use memoryStream = new MemoryStream()
+                    use memoryStream = rmsManager.GetStream("giraffe-json-deserialize")
                     do! stream.CopyToAsync(memoryStream)
                     memoryStream.Seek(0L, SeekOrigin.Begin) |> ignore
                     use streamReader = new StreamReader(memoryStream)

--- a/src/Giraffe/Json.fs
+++ b/src/Giraffe/Json.fs
@@ -29,13 +29,11 @@ module NewtonsoftJson =
     open Newtonsoft.Json
     open Newtonsoft.Json.Serialization
 
-    let recyclableMemoryStreamManager = RecyclableMemoryStreamManager()
-
     /// <summary>
     /// Default JSON serializer in Giraffe.
     /// Serializes objects to camel cased JSON code.
     /// </summary>
-    type Serializer (settings : JsonSerializerSettings) =
+    type Serializer (settings : JsonSerializerSettings, rmsManager : RecyclableMemoryStreamManager) =
         let serializer = JsonSerializer.Create settings
         let utf8EncodingWithoutBom = UTF8Encoding(false)
 
@@ -53,7 +51,7 @@ module NewtonsoftJson =
 
             member __.SerializeToStreamAsync (x : 'T) (stream : Stream) =
                 task {
-                    use memoryStream = recyclableMemoryStreamManager.GetStream()
+                    use memoryStream = rmsManager.GetStream()
                     use streamWriter = new StreamWriter(memoryStream, utf8EncodingWithoutBom)
                     use jsonTextWriter = new JsonTextWriter(streamWriter)
                     serializer.Serialize(jsonTextWriter, x)

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -9,6 +9,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.DependencyInjection.Extensions
+open Microsoft.IO
 
 // ---------------------------
 // Default middleware
@@ -113,7 +114,7 @@ type ServiceCollectionExtensions() =
     /// <returns>Returns an <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/> builder object.</returns>
     [<Extension>]
     static member AddGiraffe(svc : IServiceCollection) =
-        svc.TryAddSingleton<RecyclableMemoryStreamManager>(fun _ -> RecyclableMemoryStreamManager()) 
+        svc.TryAddSingleton<RecyclableMemoryStreamManager>(fun _ -> RecyclableMemoryStreamManager())
         svc.TryAddSingleton<Json.ISerializer>(fun sp ->
             NewtonsoftJson.Serializer(NewtonsoftJson.Serializer.DefaultSettings, sp.GetService<RecyclableMemoryStreamManager>()) :> Json.ISerializer)
         svc.TryAddSingleton<Xml.ISerializer>(fun sp ->

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -9,6 +9,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.DependencyInjection.Extensions
+open Microsoft.IO
 open FSharp.Control.Tasks
 
 // ---------------------------
@@ -114,9 +115,10 @@ type ServiceCollectionExtensions() =
     /// <returns>Returns an <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/> builder object.</returns>
     [<Extension>]
     static member AddGiraffe(svc : IServiceCollection) =
-        svc.TryAddSingleton<Json.ISerializer>(
-            NewtonsoftJson.Serializer(NewtonsoftJson.Serializer.DefaultSettings))
-        svc.TryAddSingleton<Xml.ISerializer>(
-            SystemXml.Serializer(SystemXml.Serializer.DefaultSettings))
+        svc.TryAddSingleton<RecyclableMemoryStreamManager>(fun _ -> RecyclableMemoryStreamManager()) 
+        svc.TryAddSingleton<Json.ISerializer>(fun sp ->
+            NewtonsoftJson.Serializer(NewtonsoftJson.Serializer.DefaultSettings, sp.GetService<RecyclableMemoryStreamManager>()) :> Json.ISerializer)
+        svc.TryAddSingleton<Xml.ISerializer>(fun sp ->
+            SystemXml.Serializer(SystemXml.Serializer.DefaultSettings, sp.GetService<RecyclableMemoryStreamManager>()) :> Xml.ISerializer)
         svc.TryAddSingleton<INegotiationConfig, DefaultNegotiationConfig>()
         svc

--- a/src/Giraffe/Xml.fs
+++ b/src/Giraffe/Xml.fs
@@ -24,6 +24,11 @@ module SystemXml =
     /// Serializes objects to UTF8 encoded indented XML code.
     /// </summary>
     type Serializer (settings : XmlWriterSettings, rmsManager : RecyclableMemoryStreamManager) =
+
+        new(settings : XmlWriterSettings) = Serializer(
+            settings,
+            recyclableMemoryStreamManager.Value)
+
         static member DefaultSettings =
             XmlWriterSettings(
                 Encoding           = Encoding.UTF8,
@@ -33,7 +38,7 @@ module SystemXml =
 
         interface Xml.ISerializer with
             member __.Serialize (o : obj) =
-                use stream = rmsManager.GetStream()
+                use stream = if rmsManager.ThrowExceptionOnToArray then new MemoryStream() else rmsManager.GetStream("giraffe-xml-serialize")
                 use writer = XmlWriter.Create(stream, settings)
                 let serializer = XmlSerializer(o.GetType())
                 serializer.Serialize(writer, o)

--- a/src/Giraffe/Xml.fs
+++ b/src/Giraffe/Xml.fs
@@ -13,6 +13,7 @@ module Xml =
 
 [<RequireQualifiedAccess>]
 module SystemXml =
+    open Microsoft.IO
     open System.Text
     open System.IO
     open System.Xml
@@ -22,7 +23,7 @@ module SystemXml =
     /// Default XML serializer in Giraffe.
     /// Serializes objects to UTF8 encoded indented XML code.
     /// </summary>
-    type Serializer (settings : XmlWriterSettings) =
+    type Serializer (settings : XmlWriterSettings, rmsManager : RecyclableMemoryStreamManager) =
         static member DefaultSettings =
             XmlWriterSettings(
                 Encoding           = Encoding.UTF8,
@@ -32,7 +33,7 @@ module SystemXml =
 
         interface Xml.ISerializer with
             member __.Serialize (o : obj) =
-                use stream = new MemoryStream()
+                use stream = rmsManager.GetStream()
                 use writer = XmlWriter.Create(stream, settings)
                 let serializer = XmlSerializer(o.GetType())
                 serializer.Serialize(writer, o)


### PR DESCRIPTION
- Made use of `RecyclableMemoryStreamManager` in XML serialization too
- Added an upper bound (<3.0) to Microsoft.IO.RecyclableMemoryStream because v2 [does not contain breaking changes that are really relevant here](https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/blob/master/CHANGES.md)
- Wired up `RecyclableMemoryStreamManager` through DI so that users can provide their own fine-tuned instance of the manager