### PR TITLE
.NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.100
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -71,7 +71,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.100
       - name: Create Release NuGet package
         run: |
           arrTag=(${GITHUB_REF//\// })

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -153,7 +153,7 @@ let webApp =
 Another important aspect of Giraffe is that it natively works with .NET's `Task` and `Task<'T>` objects instead of relying on F#'s historic `async {}` workflows. The main benefit of this is that it removes the necessity of converting back and forth between tasks and async workflows when building a Giraffe web application (because ASP.NET Core only works with tasks out of the box).
 
 ### Tasks - Giraffe 6 and later
-Giraffe 6 targets .NET 6, and utilies F# 6. This means we are able to use [F#'s built-in task support](https://docs.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-6#task-), and do not require any additional dependencies.
+Giraffe 6 targets .NET 6 and uses [F# 6's built-in task support](https://docs.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-6#task-) without any additional dependencies.
 
 When building web apps using Giraffe, we recommend you use this built-in support too.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -150,13 +150,17 @@ let webApp =
 ```
 
 ### Tasks
+Another important aspect of Giraffe is that it natively works with .NET's `Task` and `Task<'T>` objects instead of relying on F#'s historic `async {}` workflows. The main benefit of this is that it removes the necessity of converting back and forth between tasks and async workflows when building a Giraffe web application (because ASP.NET Core only works with tasks out of the box).
 
-Another important aspect of Giraffe is that it natively works with .NET's `Task` and `Task<'T>` objects instead of relying on F#'s `async {}` workflows. The main benefit of this is that it removes the necessity of converting back and forth between tasks and async workflows when building a Giraffe web application (because ASP.NET Core only works with tasks out of the box).
+### Tasks - Giraffe 6 and later
+Giraffe 6 targets .NET 6, and utilies F# 6. This means we are able to use [F#'s built-in task support](https://docs.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-6#task-), and do not require any additional dependencies.
 
-For this purpose Giraffe uses the `task {}` computation expression from the [Ply](https://www.nuget.org/packages/Ply/) NuGet package. Syntactically it works identical to F#'s async workflows (after opening the `FSharp.Control.Tasks` module):
+When building web apps using Giraffe, we recommend you use this built-in support too.
+
+### Tasks - Giraffe 5
+In Giraffe 5, we use the `task {}` computation expression from the [Ply](https://www.nuget.org/packages/Ply/) NuGet package. Syntactically it works identical to F#'s async workflows (after opening the `FSharp.Control.Tasks` module):
 
 ```fsharp
-open FSharp.Control.Tasks
 open Giraffe
 
 let personHandler =
@@ -171,7 +175,7 @@ The `task {}` CE is an independent project maintained by [Crowded](https://githu
 
 **IMPORTANT NOTICE**
 
-If you have `do!` bindings in your Giraffe web application then you must open the `FSharp.Control.Tasks` namespace to resolve any type inference issues:
+If you have `do!` bindings in your Giraffe 5 web application then you must open the `FSharp.Control.Tasks` namespace to resolve any type inference issues:
 
 ```fsharp
 open FSharp.Control.Tasks
@@ -212,8 +216,6 @@ Because an `HttpHandler` is defined as `HttpFunc -> HttpContext -> HttpFuncResul
 The most verbose version of defining a new `HttpHandler` function is by explicitly returning a `Task<HttpContext option>`. This is useful when an async operation needs to be called from within an `HttpHandler` function:
 
 ```fsharp
-open FSharp.Control.Tasks
-
 type Person = { Name : string }
 
 let sayHelloWorld : HttpHandler =
@@ -3137,7 +3139,6 @@ Testing a Giraffe application follows the concept of [ASP.NET Core testing](http
 ### Necessary imports:
 
 ```fsharp
-open FSharp.Control.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.TestHost
 open Microsoft.AspNetCore.Hosting
@@ -3927,7 +3928,6 @@ module Mapping =
 [<AutoOpen>]
 module HttpHandlers =
   open Giraffe.HttpHandlers
-  open Giraffe.Tasks
   open System.Threading.Tasks
 
   module Query =

--- a/samples/EndpointRoutingApp/EndpointRoutingApp/EndpointRoutingApp.fsproj
+++ b/samples/EndpointRoutingApp/EndpointRoutingApp/EndpointRoutingApp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/EndpointRoutingApp/EndpointRoutingApp/Program.fs
+++ b/samples/EndpointRoutingApp/EndpointRoutingApp/Program.fs
@@ -4,6 +4,7 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
 open Giraffe
 open Giraffe.EndpointRouting
 
@@ -63,11 +64,15 @@ let configureServices (services : IServiceCollection) =
 
 [<EntryPoint>]
 let main args =
-    WebHost
-        .CreateDefaultBuilder(args)
-        .UseKestrel()
-        .Configure(configureApp)
-        .ConfigureServices(configureServices)
-        .Build()
-        .Run()
+    let builder = WebApplication.CreateBuilder(args)
+    configureServices builder.Services
+
+    let app = builder.Build()
+
+    if app.Environment.IsDevelopment() then
+        app.UseDeveloperExceptionPage() |> ignore
+    
+    configureApp app
+    app.Run()
+
     0

--- a/src/Giraffe/Auth.fs
+++ b/src/Giraffe/Auth.fs
@@ -7,8 +7,7 @@ module Auth =
     open Microsoft.AspNetCore.Http
     open Microsoft.AspNetCore.Authentication
     open Microsoft.AspNetCore.Authorization
-    open FSharp.Control.Tasks
-
+    
     /// <summary>
     /// Challenges a client to authenticate via a specific authScheme.
     /// </summary>

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -7,7 +7,6 @@ module Core =
     open System.Globalization
     open Microsoft.AspNetCore.Http
     open Microsoft.Extensions.Logging
-    open FSharp.Control.Tasks
     open Giraffe.ViewEngine
 
     /// <summary>

--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -9,7 +9,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Routing
 open Microsoft.FSharp.Reflection
 open FSharp.Core
-open FSharp.Control.Tasks
 open Giraffe
 
 module private RouteTemplateBuilder =

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -8,7 +8,7 @@
     <NeutralLanguage>en-GB</NeutralLanguage>
 
     <!-- Build settings -->
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -47,11 +47,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.*" />
-    <PackageReference Include="System.Text.Json" Version="5.0.*" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.*" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.*" />
+    <PackageReference Include="System.Text.Json" Version="6.0.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
     <PackageReference Include="Utf8Json" Version="1.3.*" />
-    <PackageReference Include="Ply" Version="0.3.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
     <PackageReference Include="Giraffe.ViewEngine" Version="1.3.*" />
   </ItemGroup>

--- a/src/Giraffe/Helpers.fs
+++ b/src/Giraffe/Helpers.fs
@@ -4,7 +4,6 @@ namespace Giraffe
 module Helpers =
     open System
     open System.IO
-    open FSharp.Control.Tasks
 
     /// <summary>
     /// Checks if an object is not null.

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -11,7 +11,6 @@ open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Primitives
 open Microsoft.Extensions.Logging
 open Microsoft.Net.Http.Headers
-open FSharp.Control.Tasks
 open Giraffe.ViewEngine
 
 type MissingDependencyException(dependencyName : string) =

--- a/src/Giraffe/Json.fs
+++ b/src/Giraffe/Json.fs
@@ -25,7 +25,6 @@ module NewtonsoftJson =
     open System.Text
     open System.Threading.Tasks
     open Microsoft.IO
-    open FSharp.Control.Tasks
     open Newtonsoft.Json
     open Newtonsoft.Json.Serialization
 

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -9,7 +9,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.DependencyInjection.Extensions
-open FSharp.Control.Tasks
 
 // ---------------------------
 // Default middleware

--- a/src/Giraffe/Preconditional.fs
+++ b/src/Giraffe/Preconditional.fs
@@ -8,7 +8,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Http.Headers
 open Microsoft.Extensions.Primitives
 open Microsoft.Net.Http.Headers
-open FSharp.Control.Tasks
 
 type Precondition =
     | NoConditionsSpecified

--- a/src/Giraffe/Routing.fs
+++ b/src/Giraffe/Routing.fs
@@ -3,7 +3,6 @@ namespace Giraffe
 [<RequireQualifiedAccess>]
 module SubRouting =
     open Microsoft.AspNetCore.Http
-    open FSharp.Control.Tasks
 
     [<Literal>]
     let private RouteKey = "giraffe_route"

--- a/src/Giraffe/Streaming.fs
+++ b/src/Giraffe/Streaming.fs
@@ -10,7 +10,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Http.Extensions
 open Microsoft.Extensions.Primitives
 open Microsoft.Net.Http.Headers
-open FSharp.Control.Tasks
 
 // ---------------------------
 // HTTP Range parsing

--- a/tests/Giraffe.Tests/AuthTests.fs
+++ b/tests/Giraffe.Tests/AuthTests.fs
@@ -3,7 +3,6 @@ module Giraffe.Tests.AuthTests
 open System.IO
 open System.Security.Claims
 open Microsoft.AspNetCore.Http
-open FSharp.Control.Tasks
 open NSubstitute
 open Xunit
 open Giraffe

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Giraffe.Tests</AssemblyName>
   </PropertyGroup>
 
@@ -33,11 +33,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.*" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.*" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.*" />
+    <PackageReference Include="System.Net.Http" Version="4.3.*" />
+    <PackageReference Include="xunit" Version="2.4.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
     <PackageReference Include="NSubstitute" Version="4.2.*" />
   </ItemGroup>

--- a/tests/Giraffe.Tests/Helpers.fs
+++ b/tests/Giraffe.Tests/Helpers.fs
@@ -14,7 +14,6 @@ open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.TestHost
 open Microsoft.AspNetCore.Builder
 open Microsoft.Extensions.DependencyInjection
-open FSharp.Control.Tasks
 open Xunit
 open NSubstitute
 open Utf8Json

--- a/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
+++ b/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
@@ -5,7 +5,6 @@ open System.IO
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
-open FSharp.Control.Tasks
 open Xunit
 open NSubstitute
 open Giraffe

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -5,7 +5,6 @@ open System.IO
 open System.Collections.Generic
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
-open FSharp.Control.Tasks
 open Xunit
 open NSubstitute
 open Giraffe

--- a/tests/Giraffe.Tests/ModelBindingTests.fs
+++ b/tests/Giraffe.Tests/ModelBindingTests.fs
@@ -8,7 +8,6 @@ open System.Text
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
-open FSharp.Control.Tasks
 open Xunit
 open NSubstitute
 open Giraffe

--- a/tests/Giraffe.Tests/ModelValidationTests.fs
+++ b/tests/Giraffe.Tests/ModelValidationTests.fs
@@ -6,7 +6,6 @@ open System.Net.Http
 open Microsoft.AspNetCore.Builder
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
-open FSharp.Control.Tasks
 open Xunit
 open Giraffe
 

--- a/tests/Giraffe.Tests/PreconditionalTests.fs
+++ b/tests/Giraffe.Tests/PreconditionalTests.fs
@@ -7,7 +7,6 @@ open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Builder
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
-open FSharp.Control.Tasks
 open Xunit
 open Giraffe
 

--- a/tests/Giraffe.Tests/RoutingTests.fs
+++ b/tests/Giraffe.Tests/RoutingTests.fs
@@ -4,7 +4,6 @@ open System
 open System.IO
 open System.Collections.Generic
 open Microsoft.AspNetCore.Http
-open FSharp.Control.Tasks
 open Xunit
 open NSubstitute
 open Giraffe

--- a/tests/Giraffe.Tests/StreamingTests.fs
+++ b/tests/Giraffe.Tests/StreamingTests.fs
@@ -6,7 +6,6 @@ open System.Net.Http
 open Microsoft.AspNetCore.Builder
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
-open FSharp.Control.Tasks
 open Xunit
 open Giraffe
 


### PR DESCRIPTION
A few changes to take advantage of .NET 6 & ASP.NET Core 6 for a Giraffe 6 release.

- Target .NET 6
- Removed Ply (you served us well) and used baked in F# 6 support for tasks
- Updated various dependencies
- Utilise some of the minimal APIs for bootstrapping the included app