### PR TITLE
Make recyclableMemoryStreamManager internal

### DIFF
--- a/src/Giraffe/Helpers.fs
+++ b/src/Giraffe/Helpers.fs
@@ -7,7 +7,7 @@ module Helpers =
     open Microsoft.IO
 
     /// <summary>Default single RecyclableMemoryStreamManager.</summary>
-    let recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>()
+    let internal recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>()
 
     /// <summary>
     /// Checks if an object is not null.


### PR DESCRIPTION
Keep seeing this in Intellisense when it's the one in my codebase I want to use.