### PR TITLE
Updating mimetype accept header parsing to use builtin aspnet parse/methods

### DIFF
--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -7,6 +7,7 @@ module Core =
     open System.Globalization
     open Microsoft.AspNetCore.Http
     open Microsoft.Extensions.Logging
+    open Microsoft.Net.Http.Headers
     open Giraffe.ViewEngine
 
     /// <summary>
@@ -227,11 +228,13 @@ module Core =
     /// <param name="ctx"></param>
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
     let mustAccept (mimeTypes : string list) : HttpHandler =
+        let acceptedMimeTypes : MediaTypeHeaderValue list = mimeTypes |> List.map (MediaTypeHeaderValue.Parse)
         fun (next : HttpFunc) (ctx : HttpContext) ->
             let headers = ctx.Request.GetTypedHeaders()
             headers.Accept
-            |> Seq.map    (fun h -> h.ToString())
-            |> Seq.exists (fun h -> mimeTypes |> Seq.contains h)
+            |> Seq.exists (fun h ->
+                acceptedMimeTypes
+                |> List.exists (fun amt -> amt.IsSubsetOf(h)))
             |> function
                 | true  -> next ctx
                 | false -> skipPipeline

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -382,6 +382,68 @@ let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` ()
     }
 
 [<Fact>]
+let ``POST with "all-medias" header type returns the first available route`` () =
+    /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+    let ctx = Substitute.For<HttpContext>()
+    let app =
+        choose [
+            POST >=> choose [
+                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
+                route "/any" >=> mustAccept [ "application/json" ] >=> json "second route"
+                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
+            setStatusCode 404 >=> text "Not found" ]
+        
+    let headers = HeaderDictionary()
+    headers.Add("Accept", StringValues("*/*"))
+    ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/any")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "first route"
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFail $"Result was expected to be %s{expected}"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
+    }
+        
+[<Fact>]
+let ``POST with an accept header type containing a fuzzy type and concrete subtype returns the first matching route`` () =
+    /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+    let ctx = Substitute.For<HttpContext>()
+    let app =
+        choose [
+            POST >=> choose [
+                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
+                route "/any" >=> mustAccept [ "application/xml" ] >=> text "<test>second route</test>"
+                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
+            setStatusCode 404 >=> text "Not found" ]
+        
+    let headers = HeaderDictionary()
+    headers.Add("Accept", StringValues("application/*"))
+    ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/any")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "<test>second route</test>"
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFail $"Result was expected to be %s{expected}"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
+    }
+
+[<Fact>]
 let ``GET "/person" returns rendered HTML view`` () =
     let ctx = Substitute.For<HttpContext>()
 


### PR DESCRIPTION
Fixes [485](https://github.com/giraffe-fsharp/Giraffe/issues/485)

This change updates the `mustAccept` to base it's decisions on the values of parsed [MediaTypeHeaderValue](https://github.com/dotnet/aspnetcore/blob/0ee742c53f2669fd7233df6da89db5e8ab944585/src/Http/Headers/src/MediaTypeHeaderValue.cs) values instead of strings.

It utilizes the [isSubsetOf](https://github.com/dotnet/aspnetcore/blob/0ee742c53f2669fd7233df6da89db5e8ab944585/src/Http/Headers/src/MediaTypeHeaderValue.cs#L385) method of that class in order to do proper subset matching.

While the parsing is wrapped in an exception handler during the runtime execution, the construction of the function does not wrap the parsing. This is so that it will fail fast on startup (developer supplied values), but tolerate malformed values at runtime (bad user input).

I've added only a couple of tests, but believe it should suffice for this scenario since the code leans on the Net builtins.

Happy to make changes (remove rfc comments, etc) if desired.