### PR TITLE
Updating github workflow file to use nuget-acceptable version numbers for packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,11 @@ jobs:
         run: dotnet test -c Release
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: |
+          latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
+          runId=$GITHUB_RUN_ID
+          packageVersion="${latestTag//v}-build.${runId}"
+          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$packageVersion src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Fixes [513](https://github.com/giraffe-fsharp/Giraffe/issues/513) and should unblock builds.

This change alters the versioning used by github actions for builds by utilizing the Github Run Identifier as an "Additional Label" (in semver parlance) rather than a major version number.

Example (from [this failed build](https://github.com/giraffe-fsharp/Giraffe/runs/7060792905?check_suite_focus=true))

* Before: `2564178360` _(`System.ArgumentException: PackageVersion string specified '2564178360' is invalid.`)_
* After: `6.0.0-build.2564178360`

This matches the semver logic: `Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.` (ref: https://semver.org/)