### PR TITLE
RFC-compliant Content-Length handling for 1xx, 204 and 205 responses and CONNECT requests

### DIFF
--- a/src/Giraffe/Helpers.fs
+++ b/src/Giraffe/Helpers.fs
@@ -34,3 +34,44 @@ module Helpers =
             use reader = new StreamReader(filePath)
             return! reader.ReadToEndAsync()
         }
+
+    /// <summary>
+    /// Utility function for matching 1xx HTTP status codes.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>Returns true if the status code is between 100 and 199.</returns>
+    let is1xxStatusCode (statusCode : int) =
+        100 <= statusCode && statusCode <= 199
+
+    /// <summary>
+    /// Utility function for matching 2xx HTTP status codes.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>Returns true if the status code is between 200 and 299.</returns>
+    let is2xxStatusCode (statusCode : int) =
+        200 <= statusCode && statusCode <= 299
+
+    /// <summary>
+    /// Utility function for matching 3xx HTTP status codes.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>Returns true if the status code is between 300 and 399.</returns>
+    let is3xxStatusCode (statusCode : int) =
+        300 <= statusCode && statusCode <= 399
+
+    /// <summary>
+    /// Utility function for matching 4xx HTTP status codes.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>Returns true if the status code is between 400 and 499.</returns>
+    let is4xxStatusCode (statusCode : int) =
+        400 <= statusCode && statusCode <= 499
+
+    /// <summary>
+    /// Utility function for matching 5xx HTTP status codes.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code.</param>
+    /// <returns>Returns true if the status code is between 500 and 599.</returns>
+    let is5xxStatusCode (statusCode : int) =
+        500 <= statusCode && statusCode <= 599
+

--- a/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
+++ b/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
@@ -2,6 +2,7 @@ module Giraffe.Tests.HttpContextExtensionsTests
 
 open System
 open System.IO
+open System.Text
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
@@ -173,6 +174,102 @@ let ``WriteTextAsync with HTTP HEAD should not return text in body`` () =
         match result with
         | None -> assertFailf "Result was expected to be %s" expected
         | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
+let ``WriteBytesAsync should not return Content-Length in header on 100`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_ : HttpFunc) (ctx : HttpContext) ->
+            ctx.WriteBytesAsync (Encoding.UTF8.GetBytes "")
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
+    ctx.Response.StatusCode.ReturnsForAnyArgs 100 |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFail "Result was expected to be non-empty"
+        | Some ctx ->
+            Assert.Empty(ctx.Response.Headers["Content-Length"])
+    }
+
+[<Fact>]
+let ``WriteBytesAsync should not return Content-Length in header on 204`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_ : HttpFunc) (ctx : HttpContext) ->
+            ctx.WriteBytesAsync (Encoding.UTF8.GetBytes "")
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
+    ctx.Response.StatusCode.ReturnsForAnyArgs 204 |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFail "Result was expected to be non-empty"
+        | Some ctx ->
+            Assert.Empty(ctx.Response.Headers["Content-Length"])
+    }
+
+[<Fact>]
+let ``WriteBytesAsync with HTTP CONNECT should not return Content-Length in header on status code 200`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_ : HttpFunc) (ctx : HttpContext) ->
+            ctx.WriteBytesAsync (Encoding.UTF8.GetBytes "")
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "CONNECT" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
+    ctx.Response.StatusCode.ReturnsForAnyArgs 200 |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFail "Result was expected to be non-empty"
+        | Some ctx ->
+            Assert.Empty(ctx.Response.Headers["Content-Length"])
+    }
+
+[<Fact>]
+let ``WriteBytesAsync should return Content-Length 0 in header on 205`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_ : HttpFunc) (ctx : HttpContext) ->
+            ctx.WriteBytesAsync (Encoding.UTF8.GetBytes "Hello World")
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
+    ctx.Response.StatusCode.ReturnsForAnyArgs 205 |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFail "Result was expected to be non-empty"
+        | Some ctx ->
+            Assert.True(ctx.Response.Headers["Content-Length"].ToString() = "0")
     }
 
 [<Fact>]


### PR DESCRIPTION
Fixes #540