### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+<!-- Add a small description of the PR that you're submitting -->
+
+## How to test
+
+<!-- Please describe how one can test/verify that the PR is working (when applicable) -->
+
+## Related issues
+
+<!-- Point to the relevant issues addressed by this PR -->


### PR DESCRIPTION
## Description

With this PR, I'm adding a [GitHub pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

After adding this file, whenever someone opens a new PR, they'll be presented with a template file that points to relevant information that is usually necessary to understand the PR context.