### PR TITLE
Add JSON Write Async extension with custom setting

### DIFF
--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -399,6 +399,22 @@ type HttpContextExtensions() =
         |> ctx.WriteBytesAsync
 
     /// <summary>
+    /// Serializes an object to JSON and writes the output to the body of the HTTP response.
+    /// It also sets the HTTP Content-Type header to application/json and sets the Content-Length header accordingly.
+    /// The JSON serializer can be configured in the ASP.NET Core startup code by registering a custom class of type <see cref="Json.ISerializer"/>
+    /// </summary>
+    /// <param name="ctx">The current http context object.</param>
+    /// <param name="customSettings">Custom Settings for the JSON serializer.</param>
+    /// <param name="dataObj">The object to be send back to the client.</param>
+    /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
+    [<Extension>]
+    static member WriteJsonAsync<'T> (ctx : HttpContext, customSettings, dataObj : 'T) =
+        ctx.SetContentType "application/json; charset=utf-8"
+        let serializer = ctx.GetJsonSerializer()
+        serializer.SerializeToBytes(customSettings, dataObj)
+        |> ctx.WriteBytesAsync
+
+    /// <summary>
     /// Serializes an object to JSON and writes the output to the body of the HTTP response using chunked transfer encoding.
     /// It also sets the HTTP Content-Type header to application/json and sets the Transfer-Encoding header to chunked.
     /// The JSON serializer can be configured in the ASP.NET Core startup code by registering a custom class of type <see cref="Json.ISerializer"/>.

--- a/src/Giraffe/Json.fs
+++ b/src/Giraffe/Json.fs
@@ -13,6 +13,7 @@ module Json =
     type ISerializer =
         abstract member SerializeToString<'T>       : 'T -> string
         abstract member SerializeToBytes<'T>        : 'T -> byte array
+        abstract member SerializeToBytes<'T>        : obj * 'T -> byte array
         abstract member SerializeToStreamAsync<'T>  : 'T -> Stream -> Task
 
         abstract member Deserialize<'T>             : string -> 'T
@@ -50,6 +51,10 @@ module NewtonsoftJson =
 
             member __.SerializeToBytes (x : 'T) =
                 JsonConvert.SerializeObject(x, settings)
+                |> Encoding.UTF8.GetBytes
+
+            member __.SerializeToBytes (customSettings,x : 'T) =
+                JsonConvert.SerializeObject(x, (customSettings :?> JsonSerializerSettings))
                 |> Encoding.UTF8.GetBytes
 
             member __.SerializeToStreamAsync (x : 'T) (stream : Stream) =
@@ -109,6 +114,9 @@ module SystemTextJson =
 
             member __.SerializeToBytes (x : 'T) =
                 JsonSerializer.SerializeToUtf8Bytes(x, options)
+
+            member __.SerializeToBytes (customOptions,x : 'T) =
+                JsonSerializer.SerializeToUtf8Bytes(x, (customOptions :?> JsonSerializerOptions))
 
             member __.SerializeToStreamAsync (x : 'T) (stream : Stream) =
                 JsonSerializer.SerializeAsync(stream, x, options)


### PR DESCRIPTION
## Description

Create an extension method to add custom JSON serialization settings. There is no way currently to override the default JSON serializer settings.

## How to test



## Related issues

