### PR TITLE
Add `GetWebHostEnvironment` function and add deprecation warning to `GetHostingEnvironment`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -501,12 +501,12 @@ There's a handful more extension methods available to retrieve a few default dep
 
 ASP.NET Core has built in support for [working with multiple environments](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/environments) and [configuration management](https://docs.microsoft.com/en-gb/aspnet/core/fundamentals/configuration/?tabs=basicconfiguration), which both work out of the box with Giraffe.
 
-Additionally Giraffe exposes a `GetHostingEnvironment()` extension method which can be used to easier retrieve an `IHostingEnvironment` object from within an `HttpHandler` function:
+Additionally Giraffe exposes a `GetWebHostEnvironment()` extension method which can be used to easier retrieve an `IWebHostEnvironment` object from within an `HttpHandler` function:
 
 ```fsharp
 let someHttpHandler : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
-        let env = ctx.GetHostingEnvironment()
+        let env = ctx.GetWebHostEnvironment()
         // Do something with `env`...
         // Return a Task<HttpContext option>
 ```

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -60,8 +60,9 @@ type HttpContextExtensions() =
         let loggerFactory = ctx.GetService<ILoggerFactory>()
         loggerFactory.CreateLogger categoryName
 
+    [<Obsolete("Please use `GetWebHostEnvironment` as a replacement for `GetHostingEnvironment`. In the next major version this function will be removed.")>]
     /// <summary>
-    /// This function is deprecated and it's going to be removed in future releases! Gets an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/> from the request's service container.
+    /// Gets an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/> from the request's service container.
     /// </summary>
     /// <returns>Returns an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/>.</returns>
     [<Extension>]

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -61,12 +61,20 @@ type HttpContextExtensions() =
         loggerFactory.CreateLogger categoryName
 
     /// <summary>
-    /// Gets an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/> from the request's service container.
+    /// This function is deprecated and it's going to be removed in future releases! Gets an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/> from the request's service container.
     /// </summary>
     /// <returns>Returns an instance of <see cref="Microsoft.Extensions.Hosting.IHostingEnvironment"/>.</returns>
     [<Extension>]
     static member GetHostingEnvironment(ctx : HttpContext) =
         ctx.GetService<IHostingEnvironment>()
+
+    /// <summary>
+    /// Gets an instance of <see cref="Microsoft.AspNetCore.Hosting.IWebHostEnvironment"/> from the request's service container.
+    /// </summary>
+    /// <returns>Returns an instance of <see cref="Microsoft.AspNetCore.Hosting.IWebHostEnvironment"/>.</returns>
+    [<Extension>]
+    static member GetWebHostEnvironment(ctx : HttpContext) =
+        ctx.GetService<IWebHostEnvironment>()
 
     /// <summary>
     /// Gets an instance of <see cref="Giraffe.Serialization.Json.ISerializer"/> from the request's service container.
@@ -448,7 +456,7 @@ type HttpContextExtensions() =
                 match Path.IsPathRooted filePath with
                 | true  -> filePath
                 | false ->
-                    let env = ctx.GetHostingEnvironment()
+                    let env = ctx.GetWebHostEnvironment()
                     Path.Combine(env.ContentRootPath, filePath)
             ctx.SetContentType "text/html; charset=utf-8"
             let! html = readFileAsStringAsync filePath

--- a/src/Giraffe/Streaming.fs
+++ b/src/Giraffe/Streaming.fs
@@ -233,7 +233,7 @@ type StreamingExtensions() =
                 match Path.IsPathRooted filePath with
                 | true  -> filePath
                 | false ->
-                    let env = ctx.GetHostingEnvironment()
+                    let env = ctx.GetWebHostEnvironment()
                     Path.Combine(env.ContentRootPath, filePath)
             use stream = new FileStream(filePath, FileMode.Open, FileAccess.Read)
             return! ctx.WriteStreamAsync(enableRangeProcessing, stream, eTag, lastModified)


### PR DESCRIPTION
## Description

With this PR, I'm adding a new function named `GetWebHostEnvironment` to be used instead of the `GetHostingEnvironment`, that is going to be deprecated in the future.

I have updated both the documentation and the codebase itself to use this new function.

## How to test

Assert that you can build the project.

Run the automated tests:

```bash
cd tests/Giraffe.Tests/
dotnet test
```

## Related issues

- Close https://github.com/giraffe-fsharp/Giraffe/issues/524.