### PR TITLE
feat: add endpoint router wildcard

### DIFF
--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -254,6 +254,9 @@ module Routers =
         (endpoints : Endpoint list) : Endpoint =
         NestedEndpoint (path, endpoints, [])
 
+    let wildcard =
+        route "{*_}"
+
     let rec applyBefore
         (httpHandler  : HttpHandler)
         (endpoint     : Endpoint) =


### PR DESCRIPTION
## Description

This PR adds a `wildcard` handler that translates to a catch-all route template. The purpose is to have a simple, readable way of expressing a default handler.

## How to test

```fsharp
let endpoints =
  [
    GET [
      route "/a" a
      route "/b" b
    ]
    wildcard notFound
  ]
```
where `a`, `b` and `notFound` are appropriate `HttpHandlers`.

## Related issues

https://github.com/giraffe-fsharp/Giraffe/issues/534
https://github.com/giraffe-fsharp/Giraffe/issues/537