### PR TITLE
Fix EndpointRouting Guid regex + tests

### DIFF
--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -12,6 +12,10 @@ open FSharp.Core
 open Giraffe
 
 module private RouteTemplateBuilder =
+    // We use this regex route constraint to be compatible with Giraffe's default router,
+    // which supports ShortGuid's.
+    // More information on ASP.NET route constraints:
+    // https://learn.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-8.0#route-constraints
     let private guidPattern =
         "^[0-9A-Fa-f]{{8}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{12}}$|^[0-9A-Fa-f]{{32}}$|^[-_0-9A-Za-z]{{22}}$"
     let private shortIdPattern =

--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -13,7 +13,7 @@ open Giraffe
 
 module private RouteTemplateBuilder =
     let private guidPattern =
-        "([0-9A-Fa-f]{{8}}\-[0-9A-Fa-f]{{4}}\-[0-9A-Fa-f]{{4}}\-[0-9A-Fa-f]{{4}}\-[0-9A-Fa-f]{{12}}|[0-9A-Fa-f]{{32}}|[-_0-9A-Za-z]{{22}})"
+        "^[0-9A-Fa-f]{{8}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{4}}-[0-9A-Fa-f]{{12}}$|^[0-9A-Fa-f]{{32}}$|^[-_0-9A-Za-z]{{22}}$"
     let private shortIdPattern =
         "([-_0-9A-Za-z]{{10}}[048AEIMQUYcgkosw])"
 

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -1,0 +1,52 @@
+module Giraffe.Tests.EndpointRoutingTests
+
+open System
+open Microsoft.AspNetCore.Builder
+open Microsoft.Extensions.DependencyInjection
+open Xunit
+open Giraffe
+open Giraffe.EndpointRouting
+open System.Net.Http
+
+// ---------------------------------
+// routef Tests
+// ---------------------------------
+
+[<Theory>]
+[<InlineData("00000000-0000-0000-0000-0000000000000", "Not Found")>]
+[<InlineData("00000000-0000-0000-0000-000000000000", "Success: 00000000-0000-0000-0000-000000000000")>]
+[<InlineData("00000000-0000-0000-0000-00000000000", "Not Found")>]
+[<InlineData("8b3557db-fa-c0c90785ec0b", "Not Found")>]
+[<InlineData("8b3557db-fa-c0c90785ec", "Success: e7f9bdf1-5bb7-f6f9-be73-473dd3bf3979")>]
+[<InlineData("8b3557db-fa-c0c90785e", "Not Found")>]
+[<InlineData("does-not-make-sense", "Not Found")>]
+[<InlineData("1", "Not Found")>]
+let ``routef: GET "/try-a-guid/%O" returns "Success: ..."`` (potentialGuid: string, expected: string) =
+    task {
+        let endpoints: Endpoint list =
+            [ GET
+                  [ route "/" (text "Hello World")
+                    route "/foo" (text "bar")
+                    routef "/try-a-guid/%O" (fun (guid: Guid) -> text $"Success: {guid}") ] ]
+
+        let notFoundHandler = "Not Found" |> text |> RequestErrors.notFound
+
+        let configureApp (app: IApplicationBuilder) =
+            app.UseRouting()
+               .UseGiraffe(endpoints)
+               .UseGiraffe(notFoundHandler)
+
+        let configureServices (services: IServiceCollection) =
+            services.AddRouting().AddGiraffe() |> ignore
+
+        let request = 
+            createRequest HttpMethod.Get $"/try-a-guid/{potentialGuid}"
+
+        let! response = 
+            makeRequest (fun () -> configureApp) configureServices () request
+
+        let! content = 
+            response |> readText
+
+        content |> shouldEqual expected
+    }

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -21,7 +21,7 @@ open System.Net.Http
 [<InlineData("8b3557db-fa-c0c90785e", "Not Found")>]
 [<InlineData("does-not-make-sense", "Not Found")>]
 [<InlineData("1", "Not Found")>]
-let ``routef: GET "/try-a-guid/%O" returns "Success: ..."`` (potentialGuid: string, expected: string) =
+let ``routef: GET "/try-a-guid/%O" returns "Success: ..." or "Not Found"`` (potentialGuid: string, expected: string) =
     task {
         let endpoints: Endpoint list =
             [ GET

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -16,8 +16,10 @@ open System.Net.Http
 [<InlineData("00000000-0000-0000-0000-0000000000000", "Not Found")>]
 [<InlineData("00000000-0000-0000-0000-000000000000", "Success: 00000000-0000-0000-0000-000000000000")>]
 [<InlineData("00000000-0000-0000-0000-00000000000", "Not Found")>]
+[<InlineData("0000000000000000000000", "Success: d3344dd3-344d-4dd3-34d3-4d34d34d34d3")>] // ShortGuid
+[<InlineData("DBvYFN7y#$@u933Kc8pM#^", "Not Found")>]
 [<InlineData("8b3557db-fa-c0c90785ec0b", "Not Found")>]
-[<InlineData("8b3557db-fa-c0c90785ec", "Success: e7f9bdf1-5bb7-f6f9-be73-473dd3bf3979")>]
+[<InlineData("8b3557db-fa-c0c90785ec", "Success: e7f9bdf1-5bb7-f6f9-be73-473dd3bf3979")>] // ShortGuid
 [<InlineData("8b3557db-fa-c0c90785e", "Not Found")>]
 [<InlineData("does-not-make-sense", "Not Found")>]
 [<InlineData("1", "Not Found")>]

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="FormatExpressionTests.fs" />
     <Compile Include="HttpHandlerTests.fs" />
     <Compile Include="RoutingTests.fs" />
+    <Compile Include="EndpointRoutingTests.fs" />
     <Compile Include="AuthTests.fs" />
     <Compile Include="ModelBindingTests.fs" />
     <Compile Include="ModelValidationTests.fs" />


### PR DESCRIPTION
## Description

With this PR, I'm fixing the EndpointRouting Guid regex ([route constraint](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-8.0#route-constraints)) and adding more automated tests to assert that it's working.

## How to test

You can use this project example:

```fsharp
open System
open Microsoft.AspNetCore.Builder
open Microsoft.Extensions.DependencyInjection
open Microsoft.Extensions.Hosting
open Giraffe
open Giraffe.EndpointRouting

let endpoints =
    [ GET
          [ route "/" (text "Hello World")
            routef "/try-a-guid/%O" (fun (guid: Guid) -> text $"Success: {guid}") ] ]

let notFoundHandler = "Not Found" |> text |> RequestErrors.notFound

let configureApp (appBuilder: IApplicationBuilder) =
    appBuilder.UseRouting().UseGiraffe(endpoints).UseGiraffe(notFoundHandler)

let configureServices (services: IServiceCollection) =
    services.AddRouting().AddGiraffe() |> ignore

[<EntryPoint>]
let main args =
    let builder = WebApplication.CreateBuilder(args)
    configureServices builder.Services

    let app = builder.Build()

    configureApp app
    app.Run()

    0
```

And test with some inputs. For example:

```bash
# must not find
curl http://localhost:5000/try-a-guid/8b3557db-fa-c0c90785ec0b

# must work fine
curl http://localhost:5000/try-a-guid/8b3557db-fa-c0c90785ec
# ...
```

You can find more Guid ideas at the automated tests file.

## Related issues

- Close https://github.com/giraffe-fsharp/Giraffe/issues/576