### PR TITLE
Fix pre-release/release workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  push:
   release:
     types:
       - published
@@ -67,12 +68,12 @@ jobs:
           echo Clean Version: $VERSION
 
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
-      - name: Push to GitHub Feed
-        run: |
-          for f in ./nupkg/*.nupkg
-          do
-            echo $f
-            curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
-          done
-      - name: Push to NuGet Feed
-        run: dotnet nuget push ./nupkg/*.nupkg --source $NUGET_FEED --skip-duplicate --api-key $NUGET_KEY
+      # - name: Push to GitHub Feed
+      #   run: |
+      #     for f in ./nupkg/*.nupkg
+      #     do
+      #       echo $f
+      #       curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
+      #     done
+      # - name: Push to NuGet Feed
+      #   run: dotnet nuget push ./nupkg/*.nupkg --source $NUGET_FEED --skip-duplicate --api-key $NUGET_KEY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish
 
 on:
-  push:
   release:
     types:
       - published
@@ -27,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,9 +63,8 @@ jobs:
           VERSION="${arrTag[2]}"
           echo Version: $VERSION
           
-          # VERSION="${VERSION//v}"
-          # echo Clean Version: $VERSION
-          VERSION="6.4.1-alpha-2"
+          VERSION="${VERSION//v}"
+          echo Clean Version: $VERSION
 
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Push to GitHub Feed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,8 +64,9 @@ jobs:
           VERSION="${arrTag[2]}"
           echo Version: $VERSION
           
-          VERSION="${VERSION//v}"
-          echo Clean Version: $VERSION
+          # VERSION="${VERSION//v}"
+          # echo Clean Version: $VERSION
+          VERSION="6.4.1-alpha-2"
 
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
       # - name: Push to GitHub Feed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,43 +43,10 @@ jobs:
         run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test -c Release
-      - name: Pack
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
-          runId=$GITHUB_RUN_ID
-          packageVersion="${latestTag//v}-build.${runId}"
-          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$packageVersion src/$PROJECT_NAME/$PROJECT_NAME.*proj
-      - name: Upload Artifact
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: nupkg
-          path: ./src/${{ env.PROJECT_NAME }}/bin/Release/*.nupkg
-
-  prerelease:
-    name: Publish a pre-release version
-    needs: build
-    if: github.event.release.prerelease == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: nupkg
-          path: ./nupkg
-      - name: Push to GitHub Feed
-        run: |
-          for f in ./nupkg/*.nupkg
-          do
-            echo $f
-            curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
-          done
           
   deploy:
-    name: Publish a release version
+    name: Publish a new version
     needs: build
-    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -95,13 +62,16 @@ jobs:
           arrTag=(${GITHUB_REF//\// })
           VERSION="${arrTag[2]}"
           echo Version: $VERSION
+          
           VERSION="${VERSION//v}"
           echo Clean Version: $VERSION
+
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Push to GitHub Feed
         run: |
           for f in ./nupkg/*.nupkg
           do
+            echo $f
             curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
           done
       - name: Push to NuGet Feed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,12 +69,12 @@ jobs:
           VERSION="6.4.1-alpha-2"
 
           dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
-      # - name: Push to GitHub Feed
-      #   run: |
-      #     for f in ./nupkg/*.nupkg
-      #     do
-      #       echo $f
-      #       curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
-      #     done
-      # - name: Push to NuGet Feed
-      #   run: dotnet nuget push ./nupkg/*.nupkg --source $NUGET_FEED --skip-duplicate --api-key $NUGET_KEY
+      - name: Push to GitHub Feed
+        run: |
+          for f in ./nupkg/*.nupkg
+          do
+            echo $f
+            curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
+          done
+      - name: Push to NuGet Feed
+        run: dotnet nuget push ./nupkg/*.nupkg --source $NUGET_FEED --skip-duplicate --api-key $NUGET_KEY


### PR DESCRIPTION
## Description

Although the `prerelease` workflow was running with the latest PR changes, it was still not creating the new nuget version, since it was not running the [dotnet nuget push](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push) command.

After realizing this problem, I figured out that in this case it would be better to use the `deploy` workflow that does the job correctly. This way, I'm proposing the removal of `prerelease` workflow and the usage of `deploy` for both `pre-release`s and `release`s on GitHub.

Please let me know what you think.

## How to test

Check this CI execution: [link](https://github.com/giraffe-fsharp/Giraffe/actions/runs/9070910047/job/24923641652?pr=596).

Notice that the "new" pre-release version was created and it's available on [nuget](https://www.nuget.org/packages/Giraffe#versions-body-tab):

![image](https://github.com/giraffe-fsharp/Giraffe/assets/50725287/dc204152-e709-4710-bb57-d6a7a9b093cf)


## Related issues

- Continuation of https://github.com/giraffe-fsharp/Giraffe/pull/595