### PR TITLE
Benchmark `WriteBytesAsync` optimization

### DIFF
--- a/Giraffe.sln
+++ b/Giraffe.sln
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_root", "_root", "{FADD8661
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ResponseCachingApp", "samples\ResponseCachingApp\ResponseCachingApp.fsproj", "{FA102AC4-4608-42F9-86C1-1472B416A76E}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Benchmarks", "benchmarks\Benchmarks.fsproj", "{8C9B540A-EF5E-44A7-95B1-63444E326D68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -90,6 +92,18 @@ Global
 		{FA102AC4-4608-42F9-86C1-1472B416A76E}.Release|x64.Build.0 = Release|Any CPU
 		{FA102AC4-4608-42F9-86C1-1472B416A76E}.Release|x86.ActiveCfg = Release|Any CPU
 		{FA102AC4-4608-42F9-86C1-1472B416A76E}.Release|x86.Build.0 = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|x64.Build.0 = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Debug|x86.Build.0 = Debug|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|x64.ActiveCfg = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|x64.Build.0 = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|x86.ActiveCfg = Release|Any CPU
+		{8C9B540A-EF5E-44A7-95B1-63444E326D68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmarks/Benchmarks.fsproj
+++ b/benchmarks/Benchmarks.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../src/Giraffe/Giraffe.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Program.fs
+++ b/benchmarks/Program.fs
@@ -1,0 +1,50 @@
+open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Running
+open Giraffe
+open Microsoft.AspNetCore.Http
+open System.Text
+open System.Threading.Tasks
+open NSubstitute
+open System.IO
+
+let mockHttpFunc: HttpFunc = (Some >> Task.FromResult)
+
+let mockCtx: HttpContext =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
+    ctx.Response.StatusCode.ReturnsForAnyArgs 200 |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    ctx
+
+let testHandler__v1 (handlerReturn: byte array) : HttpHandler =
+    fun (_ : HttpFunc) (ctx : HttpContext) ->
+        ctx.WriteBytesAsync (handlerReturn)
+
+let testHandler__v2 (handlerReturn: byte array) : HttpHandler =
+    fun (_ : HttpFunc) (ctx : HttpContext) ->
+        ctx.OptimizedWriteBytesAsync (handlerReturn)
+
+[<MemoryDiagnoser>]
+type WriteBytesAsync() =
+    
+    [<Params (100, 500, 1000)>] 
+    member val ListSize : int = 0 with get, set
+
+    member self.handlerReturn : byte array =
+        [ 0 .. self.ListSize ] |> List.map (fun _ -> "a") |> List.reduce (+) |> Encoding.UTF8.GetBytes
+
+    [<Benchmark(Baseline = true)>]
+    member self.V1 () =
+        testHandler__v1 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+
+    [<Benchmark>]
+    member self.V2 () =
+        testHandler__v2 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+
+[<EntryPoint>]
+let main (_args: string[]) : int =
+    BenchmarkRunner.Run<WriteBytesAsync>() |> ignore
+    0

--- a/benchmarks/Program.fs
+++ b/benchmarks/Program.fs
@@ -30,7 +30,7 @@ let testHandler__v2 (handlerReturn: byte array) : HttpHandler =
 [<MemoryDiagnoser>]
 type WriteBytesAsync() =
     
-    [<Params (100, 500, 1000)>] 
+    [<Params (100, 500, 1000, 5000)>] 
     member val ListSize : int = 0 with get, set
 
     member self.handlerReturn : byte array =
@@ -38,11 +38,19 @@ type WriteBytesAsync() =
 
     [<Benchmark(Baseline = true)>]
     member self.V1 () =
-        testHandler__v1 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+        task {
+            let! _res = testHandler__v1 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+
+            return ()
+        }
 
     [<Benchmark>]
     member self.V2 () =
-        testHandler__v2 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+        task {
+            let! _res = testHandler__v2 (self.handlerReturn) (mockHttpFunc) (mockCtx)
+
+            return ()
+        }
 
 [<EntryPoint>]
 let main (_args: string[]) : int =


### PR DESCRIPTION
## Description

With this PR, I'm adding a simple code used to benchmark PR https://github.com/giraffe-fsharp/Giraffe/pull/600, inspired by this [test](https://github.com/giraffe-fsharp/Giraffe/blob/master/tests/Giraffe.Tests/HttpContextExtensionsTests.fs#L180).

For now, I don't have the intention to merge this PR.

Results from my local environment:

```bash
# how to run
cd benchmarks/
sudo dotnet run -c Release
```

```
// * Summary *

BenchmarkDotNet v0.13.10, Ubuntu 22.04.4 LTS (Jammy Jellyfish)
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET SDK 8.0.202
  [Host]     : .NET 8.0.3 (8.0.324.11423), X64...
  DefaultJob : .NET 8.0.3 (8.0.324.11423), X64...
```

| Method | ListSize | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0       | Gen1     | Allocated   | Alloc Ratio |
|------- |--------- |------------:|----------:|----------:|------:|--------:|-----------:|---------:|------------:|------------:|
| V1     | 100      |    26.07 us |  0.497 us |  0.553 us |  1.00 |    0.00 |     4.3945 |   1.0986 |    27.38 KB |        1.00 |
| V2     | 100      |    26.36 us |  0.517 us |  0.484 us |  1.01 |    0.02 |     4.4556 |   1.1292 |    27.38 KB |        1.00 |
|        |          |             |           |           |       |         |            |          |             |             |
| V1     | 500      |    85.47 us |  0.843 us |  0.704 us |  1.00 |    0.00 |   144.0430 |   9.5215 |   298.14 KB |        1.00 |
| V2     | 500      |    85.74 us |  1.224 us |  1.085 us |  1.00 |    0.02 |   144.0430 |   9.5215 |   298.14 KB |        1.00 |
|        |          |             |           |           |       |         |            |          |             |             |
| V1     | 1000     |   228.97 us |  4.474 us |  4.394 us |  1.00 |    0.00 |   524.9023 |  14.1602 |  1076.04 KB |        1.00 |
| V2     | 1000     |   228.11 us |  3.399 us |  3.013 us |  1.00 |    0.02 |   524.9023 |  14.1602 |  1076.04 KB |        1.00 |
|        |          |             |           |           |       |         |            |          |             |             |
| V1     | 5000     | 2,892.29 us | 34.598 us | 32.363 us |  1.00 |    0.00 | 12000.0000 | 300.7813 | 24876.91 KB |        1.00 |
| V2     | 5000     | 2,889.10 us | 40.907 us | 36.263 us |  1.00 |    0.02 | 12000.0000 | 300.7813 | 24876.91 KB |        1.00 |

```
// * Hints *
Outliers
  WriteBytesAsync.V1: Default -> 2 outliers were removed (88.32 us, 95.53 us)
  WriteBytesAsync.V2: Default -> 1 outlier  was  removed (96.43 us)
  WriteBytesAsync.V1: Default -> 3 outliers were removed (250.95 us..253.84 us)
  WriteBytesAsync.V2: Default -> 1 outlier  was  removed (254.30 us)
  WriteBytesAsync.V2: Default -> 1 outlier  was  removed (2.98 ms)

// * Legends *
  ListSize    : Value of the 'ListSize' parameter
  Mean        : Arithmetic mean of all measurements
  Error       : Half of 99.9% confidence interval
  StdDev      : Standard deviation of all measurements
  Ratio       : Mean of the ratio distribution ([Current]/[Baseline])
  RatioSD     : Standard deviation of the ratio distribution ([Current]/[Baseline])
  Gen0        : GC Generation 0 collects per 1000 operations
  Gen1        : GC Generation 1 collects per 1000 operations
  Allocated   : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  Alloc Ratio : Allocated memory ratio distribution ([Current]/[Baseline])
  1 us        : 1 Microsecond (0.000001 sec)
```