### PR TITLE
Add F# compatible json serializer

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2971,10 +2971,6 @@ For example, one could define a `Newtonsoft.Json` serializer:
          let serializer = JsonSerializer.Create settings
          let utf8EncodingWithoutBom = UTF8Encoding(false)
 
-         new(settings : JsonSerializerSettings) = Serializer(
-             settings,
-             recyclableMemoryStreamManager.Value)
-
          static member DefaultSettings =
              JsonSerializerSettings(
                  ContractResolver = CamelCasePropertyNamesContractResolver())
@@ -3024,7 +3020,8 @@ let configureServices (services : IServiceCollection) =
     services.AddGiraffe() |> ignore
 
     // Now register your custom Json.ISerializer
-    services.AddSingleton<Json.ISerializer, NewtonsoftJson.Serializer>() |> ignore
+    services.AddSingleton<Json.ISerializer>(fun serviceProvider ->
+            NewtonsoftJson.Serializer(JsonSerializerSettings(), serviceProvider.GetService<Microsoft.IO.RecyclableMemoryStreamManager>()) :> Json.ISerializer) |> ignore
 
 [<EntryPoint>]
 let main _ =

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2935,6 +2935,9 @@ Please visit the [Giraffe.ViewEngine](https://github.com/giraffe-fsharp/Giraffe.
 
 By default Giraffe uses `System.Text.Json` for (de-)serializing JSON content. An application can modify the default serializer by registering a new dependency which implements the `Json.ISerializer` interface during application startup.
 
+It's possible to use a serializer compatible with Fsharp types: `Json.FsharpFriendlySerializer` instead of `Json.Serializer`.  
+This uses `FSharp.SystemTextJson` to customize `System.Text.Json`.
+
 #### Using a different JSON serializer
 
 You can change the entire underlying JSON serializer by creating a new class which implements the `Json.ISerializer` interface:

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -66,6 +66,7 @@
     <PackageReference Include="FSharp.Core" Version="6.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.*" />
     <PackageReference Include="System.Text.Json" Version="8.0.*" />
+    <PackageReference Include="FSharp.SystemTextJson" Version="1.3.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.*" PrivateAssets="All" />
     <PackageReference Include="Giraffe.ViewEngine" Version="1.4.*" />
   </ItemGroup>

--- a/src/Giraffe/Json.fs
+++ b/src/Giraffe/Json.fs
@@ -6,6 +6,7 @@ module Json =
     open System.IO
     open System.Text.Json
     open System.Threading.Tasks
+    open System.Text.Json.Serialization
 
     /// <summary>
     /// Interface defining JSON serialization methods.
@@ -54,3 +55,19 @@ module Json =
 
             member __.DeserializeAsync<'T> (stream : Stream) : Task<'T> =
                 JsonSerializer.DeserializeAsync<'T>(stream, options).AsTask()
+    
+    module FsharpFriendlySerializer =
+        let DefaultOptions =
+           JsonFSharpOptions.Default()
+        
+        let private appendJsonFSharpOptions (fsharpOptions: JsonFSharpOptions) (jsonOptions: JsonSerializerOptions) =
+            jsonOptions.Converters.Add(JsonFSharpConverter(fsharpOptions))
+            jsonOptions
+        
+        let buildConfig (fsharpOptions: JsonFSharpOptions option) (jsonOptions: JsonSerializerOptions option) =
+            jsonOptions
+            |> Option.defaultValue (JsonSerializerOptions())
+            |> appendJsonFSharpOptions (fsharpOptions |> Option.defaultValue DefaultOptions)
+    
+    type FsharpFriendlySerializer (?fsharpOptions: JsonFSharpOptions, ?jsonOptions: JsonSerializerOptions) =
+        inherit Serializer(FsharpFriendlySerializer.buildConfig fsharpOptions jsonOptions)


### PR DESCRIPTION
## Description

Add F# compatible json serializer with `FSharp.SystemTextJson`: `Json.FsharpFriendlySerializer`

## How to test

Use `Json.FsharpFriendlySerializer`

## Related issues

https://github.com/giraffe-fsharp/Giraffe/issues/604