### PR TITLE
HandleOptionGracefullyAnalyzer for ETag and Last-Modified at Preconditional.fs 

### DIFF
--- a/src/Giraffe/Preconditional.fs
+++ b/src/Giraffe/Preconditional.fs
@@ -150,12 +150,12 @@ type PreconditionExtensions() =
             | ConditionFailed -> ConditionFailed
             | ResourceNotModified -> ResourceNotModified
 
-        // Set ETag and Last-Modified in the response
-        if eTag.IsSome then
-            responseHeaders.ETag <- eTag.Value
+        // Set ETag in the response
+        eTag |> Option.iter (fun eTagValue -> responseHeaders.ETag <- eTagValue)
 
-        if lastModified.IsSome then
-            responseHeaders.LastModified <- Nullable(lastModified.Value.CutOffMs())
+        // Set Last-Modified in the response
+        lastModified
+        |> Option.iter (fun lastModifiedValue -> responseHeaders.LastModified <- Nullable(lastModifiedValue.CutOffMs()))
 
         // Validate headers in correct precedence
         // RFC: https://tools.ietf.org/html/rfc7232#section-6


### PR DESCRIPTION
## Description

With this PR, I'm solving this scan result (ionide.Analyzers) for the `Preconditional.fs` file, rule id IONIDE-006:

> Replace unsafe option unwrapping with graceful handling of each case.

+ Documentation [link](https://ionide.io/ionide-analyzers/suggestion/006.html#HandleOptionGracefullyAnalyzer).

> [!NOTE]
> This will not change any project behavior.

Solves:

+ https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/15
+ https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/14