### PR TITLE
Fix `ReadBodyFromRequestAsync` disposing `ctx.Request.Body`

### DIFF
--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -203,7 +203,7 @@ type HttpContextExtensions() =
     [<Extension>]
     static member ReadBodyFromRequestAsync(ctx: HttpContext) =
         task {
-            use reader = new StreamReader(ctx.Request.Body, Encoding.UTF8)
+            use reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen = true)
             return! reader.ReadToEndAsync()
         }
 

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -208,6 +208,21 @@ type HttpContextExtensions() =
         }
 
     /// <summary>
+    /// Reads the entire body of the <see cref="Microsoft.AspNetCore.Http.HttpRequest"/> asynchronously and returns it as a <see cref="System.String"/> value. This function let's you decide if you want to leave the ctx.Request.Body element open or not.
+    /// </summary>
+    /// <param name="ctx">The current http context object.</param>
+    /// <param name="leaveOpen">`true` to leave the stream open after the StreamReader object is disposed; otherwise, `false`.</param>
+    /// <returns>Returns the contents of the request body as a <see cref="System.Threading.Tasks.Task{System.String}"/>.</returns>
+    [<Extension>]
+    static member ReadBodyFromRequestAsync(ctx: HttpContext, leaveOpen: bool) =
+        task {
+            use reader =
+                new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen = leaveOpen)
+
+            return! reader.ReadToEndAsync()
+        }
+
+    /// <summary>
     /// Reads the entire body of the <see cref="Microsoft.AspNetCore.Http.HttpRequest"/> asynchronously and returns it as a <see cref="System.String"/> value.
     /// This method buffers the response and makes subsequent reads possible.
     /// </summary>

--- a/tests/Giraffe.Tests/Helpers.fs
+++ b/tests/Giraffe.Tests/Helpers.fs
@@ -196,9 +196,14 @@ let hasLastModified (lastModified: DateTimeOffset) (response: HttpResponseMessag
     Assert.Equal(lastModified, response.Content.Headers.LastModified.Value)
     response
 
+let getReqBody (ctx: HttpContext) =
+    ctx.Request.Body.Position <- 0L
+    use reader = new StreamReader(ctx.Request.Body, Encoding.UTF8, leaveOpen = true)
+    reader.ReadToEnd()
+
 let getBody (ctx: HttpContext) =
     ctx.Response.Body.Position <- 0L
-    use reader = new StreamReader(ctx.Response.Body, Encoding.UTF8)
+    use reader = new StreamReader(ctx.Response.Body, Encoding.UTF8, leaveOpen = true)
     reader.ReadToEnd()
 
 let readText (response: HttpResponseMessage) = response.Content.ReadAsStringAsync()


### PR DESCRIPTION
## Description

As noticed by @xperiandri, the `ReadBodyFromRequestAsync` seems to be incorrectly disposing the `ctx.Request.Body`. I'm adopting the suggestion from @Banashek, to use the `leaveOpen = true` parameter.

From the [docs](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader.-ctor?view=net-8.0#overloads):

> Unless you set the leaveOpen parameter to true, the [StreamReader](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader?view=net-8.0) object calls [Dispose()](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.dispose?view=net-8.0#system-io-stream-dispose) on the provided [Stream](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream?view=net-8.0) object when [StreamReader.Dispose](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamreader.dispose?view=net-8.0) is called.

## How to test

Check the automated tests.

*Thanks @Banashek and @1eyewonder for the comments and ideas.

## Related issues

- Close https://github.com/giraffe-fsharp/Giraffe/issues/564