### PR TITLE
Code scanning fix patches

### DIFF
--- a/src/Giraffe/RequestLimitation.fs
+++ b/src/Giraffe/RequestLimitation.fs
@@ -44,7 +44,7 @@ let mustAcceptAny (mimeTypes: string list) (optionalErrorHandler: OptionalErrorH
             )
 
         match Option.ofObj (headers.Accept :> _ seq) with
-        | Some xs when Seq.map (_.ToString()) xs |> Seq.exists (fun x -> Seq.contains x mimeTypes) -> next ctx
+        | Some xs when Seq.map (_.ToString()) xs |> Seq.exists (fun x -> List.contains x mimeTypes) -> next ctx
         | Some xs when Seq.isEmpty xs -> headerNotFoundHandler earlyReturn ctx
         | Some _ -> invalidHeaderValueHandler earlyReturn ctx
         | None -> headerNotFoundHandler earlyReturn ctx
@@ -75,7 +75,7 @@ let hasAnyContentTypes (contentTypes: string list) (optionalErrorHandler: Option
             )
 
         match Option.ofObj ctx.Request.ContentType with
-        | Some header when Seq.contains header contentTypes -> next ctx
+        | Some header when List.contains header contentTypes -> next ctx
         | Some header when String.IsNullOrEmpty header -> headerNotFoundHandler earlyReturn ctx
         | Some _ -> invalidHeaderValueHandler earlyReturn ctx
         | None -> headerNotFoundHandler earlyReturn ctx

--- a/src/Giraffe/RequestLimitation.fs
+++ b/src/Giraffe/RequestLimitation.fs
@@ -43,8 +43,16 @@ let mustAcceptAny (mimeTypes: string list) (optionalErrorHandler: OptionalErrorH
                 )
             )
 
+        let mimeTypesSet = Set.ofList mimeTypes
+
         match Option.ofObj (headers.Accept :> _ seq) with
-        | Some xs when Seq.map (_.ToString()) xs |> Seq.exists (fun x -> List.contains x mimeTypes) -> next ctx
+        | Some xs when
+            Seq.map (_.ToString()) xs
+            |> Set.ofSeq
+            |> Set.intersect mimeTypesSet
+            |> (Set.isEmpty >> not)
+            ->
+            next ctx
         | Some xs when Seq.isEmpty xs -> headerNotFoundHandler earlyReturn ctx
         | Some _ -> invalidHeaderValueHandler earlyReturn ctx
         | None -> headerNotFoundHandler earlyReturn ctx

--- a/src/Giraffe/ResponseCaching.fs
+++ b/src/Giraffe/ResponseCaching.fs
@@ -55,14 +55,17 @@ module ResponseCaching =
             | Public duration -> tHeaders.CacheControl <- cacheHeader true duration
             | Private duration -> tHeaders.CacheControl <- cacheHeader false duration
 
-            if vary.IsSome then
-                headers.[HeaderNames.Vary] <- StringValues [| vary.Value |]
+            match vary with
+            | Some value -> headers.[HeaderNames.Vary] <- StringValues [| value |]
+            | None -> ()
 
-            if varyByQueryKeys.IsSome then
+            match varyByQueryKeys with
+            | Some value ->
                 let responseCachingFeature = ctx.Features.Get<IResponseCachingFeature>()
 
                 if isNotNull responseCachingFeature then
-                    responseCachingFeature.VaryByQueryKeys <- varyByQueryKeys.Value
+                    responseCachingFeature.VaryByQueryKeys <- value
+            | None -> ()
 
             next ctx
 

--- a/src/Giraffe/ResponseCaching.fs
+++ b/src/Giraffe/ResponseCaching.fs
@@ -55,17 +55,16 @@ module ResponseCaching =
             | Public duration -> tHeaders.CacheControl <- cacheHeader true duration
             | Private duration -> tHeaders.CacheControl <- cacheHeader false duration
 
-            match vary with
-            | Some value -> headers.[HeaderNames.Vary] <- StringValues [| value |]
-            | None -> ()
+            vary
+            |> Option.iter (fun value -> headers.[HeaderNames.Vary] <- StringValues [| value |])
 
-            match varyByQueryKeys with
-            | Some value ->
+            varyByQueryKeys
+            |> Option.iter (fun value ->
                 let responseCachingFeature = ctx.Features.Get<IResponseCachingFeature>()
 
                 if isNotNull responseCachingFeature then
                     responseCachingFeature.VaryByQueryKeys <- value
-            | None -> ()
+            )
 
             next ctx
 

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="HttpHandlerTests.fs" />
     <Compile Include="RoutingTests.fs" />
     <Compile Include="RequestLimitationTests.fs" />
+    <Compile Include="ResponseCachingTests.fs" />
     <Compile Include="EndpointRoutingTests.fs" />
     <Compile Include="AuthTests.fs" />
     <Compile Include="ModelBindingTests.fs" />

--- a/tests/Giraffe.Tests/ResponseCachingTests.fs
+++ b/tests/Giraffe.Tests/ResponseCachingTests.fs
@@ -1,0 +1,51 @@
+module Giraffe.Tests.ResponseCachingTests
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Http
+open Microsoft.Net.Http.Headers
+open Microsoft.Extensions.Primitives
+open Giraffe
+open NSubstitute
+open Xunit
+
+// ---------------------------------
+// Request caching tests
+// ---------------------------------
+
+[<Fact>]
+let ``responseCaching is updating 'vary' response header`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let responseCachingMiddleware: HttpHandler =
+        responseCaching
+            (Public(TimeSpan.FromSeconds(float 30)))
+            (Some "Accept, Accept-Encoding")
+            (Some [| "query1"; "query2" |])
+
+    let app =
+        GET
+        >=> route "/ok"
+        >=> responseCachingMiddleware
+        >=> setStatusCode 200
+        >=> text "ok"
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs("/ok") |> ignore
+    ctx.Response.Headers.ReturnsForAnyArgs(new HeaderDictionary()) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFail "Non expected result"
+        | Some ctx ->
+            Assert.Equal(StatusCodes.Status200OK, ctx.Response.StatusCode)
+
+            let expectedVaryHeader = StringValues [| "Accept, Accept-Encoding" |] |> string
+            Assert.Equal(string ctx.Response.Headers.[HeaderNames.Vary], expectedVaryHeader)
+
+            let expectedBody = "ok"
+            Assert.Equal(expectedBody, getBody ctx)
+    }


### PR DESCRIPTION
## Description

Fix the following code scan warnings:

- Replace unsafe option unwrapping with graceful handling of each case.
  - https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/36
  - https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/9
- Checks if calls of Seq functions can be replaced with functions from the collection modules
  - https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/32
  - https://github.com/giraffe-fsharp/Giraffe/security/code-scanning/31

Before this PR (29 open items):

![image](https://github.com/user-attachments/assets/f794aa0d-0c8f-4fee-b04c-259dec44021c)

After this PR (25 open items):

![image](https://github.com/user-attachments/assets/65d0de9d-51d1-4a26-a4eb-0f6f48aae45b)

## How to test

Check CI.