### PR TITLE
Add .NET 9 as target framework, fine-tune dependabot, update CI and clean tests removing .NET 6/7 from target frameworks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,11 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Maintain dependencies for nuget
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/"
+      - "/src/Giraffe/"
+      - "/tests/Giraffe.Tests/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,8 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,7 @@ jobs:
             6.x
             7.x
             8.x
+            9.x
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -48,7 +49,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: 9.x
       - name: Restore tools
         run: dotnet tool restore
       - name: Build solution

--- a/.github/workflows/fantomas-check.yml
+++ b/.github/workflows/fantomas-check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   fantomas-check:
     name: Code format check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/fantomas-check.yml
+++ b/.github/workflows/fantomas-check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   fantomas-check:
     name: Code format check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
             6.x
             7.x
             8.x
+            9.x
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -57,6 +58,7 @@ jobs:
             6.x
             7.x
             8.x
+            9.x
       - name: Create Release NuGet package
         run: |
           arrTag=(${GITHUB_REF//\// })

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -9,7 +9,7 @@
     <NeutralLanguage>en-GB</NeutralLanguage>
 
     <!-- Build settings -->
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <AssemblyName>Giraffe.Tests</AssemblyName>
   </PropertyGroup>
 
@@ -34,18 +34,21 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
- <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.*" />
- </ItemGroup>
+  </ItemGroup>
 
-
- <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.*" />
- </ItemGroup>
+  </ItemGroup>
 
- <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.*" />
- </ItemGroup>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.*" />

--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AssemblyName>Giraffe.Tests</AssemblyName>
   </PropertyGroup>
 
@@ -34,14 +34,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.*" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.*" />
   </ItemGroup>
@@ -51,15 +43,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.*" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.*" />
-    <PackageReference Include="System.Net.Http" Version="4.3.*" />
-    <PackageReference Include="xunit" Version="2.7.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.*">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.*" />
+    <PackageReference Include="xunit" Version="2.9.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="5.1.*" />
+    <PackageReference Include="NSubstitute" Version="5.3.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

With this PR, 

- I'm adding .NET 9 as a target framework;
- Changing **fantomas** CI to run using ubuntu-latest;
- Changing **build-and-test** push trigger to execute only for pushes to the `master` branch;
- Update dependabot configuration to scan multiple [directories](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--);
- Clean test dependencies and remove .NET 6 and 7 from target frameworks.

## How to test

Check CI.