### PR TITLE
Revert dependabot configuration to scan only one directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,8 @@ updates:
     schedule:
       interval: "weekly"
 
-  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
+  # Maintain dependencies for nuget
   - package-ecosystem: "nuget"
-    directories:
-      - "/"
-      - "/src/Giraffe/"
-      - "/tests/Giraffe.Tests/"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Description

Revert the dependabot setup introduced with PR https://github.com/giraffe-fsharp/Giraffe/pull/639.

Reason: It started creating some duplicated PRs:

![image](https://github.com/user-attachments/assets/855835e4-4eaf-4c70-9503-b6d65ee99078)