### PR TITLE
Fix assembly version

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -8,7 +8,7 @@ This documentation must be used as a guide for maintainers and developers for bu
     1. `git checkout master`
 2. Add a new entry at the top of the RELEASE_NOTES.md with a version and a date.
     1. If possible link to the relevant issues and PRs and credit the author of the PRs
-3. Update the **AssemblyVersion** attribute at *src/Giraffe.fsproj*, using the same version defined at the RELEASE_NOTES.md.
+3. Update the **Version** attribute at *src/Giraffe.fsproj*, using the same version defined at the RELEASE_NOTES.md.
     1. Notice that this can be automated in the future with [ionide/KeepAChangelog](https://github.com/ionide/KeepAChangelog).
 4. Create a new commit
     1. `git add RELEASE_NOTES.md`

--- a/src/Giraffe/Giraffe.fsproj
+++ b/src/Giraffe/Giraffe.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- General -->
     <AssemblyName>Giraffe</AssemblyName>
-    <AssemblyVersion>8.0.0-alpha-001</AssemblyVersion>
+    <Version>8.0.0-alpha-001</Version>
     <Description>A native functional ASP.NET Core web framework for F# developers.</Description>
     <Copyright>Copyright 2020 Dustin Moris Gorski</Copyright>
     <Authors>Dustin Moris Gorski and contributors</Authors>


### PR DESCRIPTION
## Description

With this PR, I'm replacing the `AssemblyVersion` with `Version` metadata from Giraffe.fsproj.

## How to test

- Build the project locally and inspect the generated `dll`.
- Assert the metadata is correct. For example:

![image](https://github.com/user-attachments/assets/db8e6133-0abb-47fa-a676-8cdcb4927a94)

## Related issues

Related to this comment: https://github.com/giraffe-fsharp/Giraffe/pull/629#issuecomment-2799893629.