### PR TITLE
Enhance routef support for named parameters and improve documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1089,6 +1089,9 @@ let fooHandler (first : string,
 
 let webApp =
     choose [
+        // Named parameter example:
+        routef "/pet/%i:petId" (fun (petId: int) -> text (sprintf "PetId: %i" petId))
+        // Classic usage:
         routef "/foo/%s/%s/%i" fooHandler
         routef "/bar/%O" (fun guid -> text (guid.ToString()))
 
@@ -1099,7 +1102,7 @@ let webApp =
 
 The `routef` http handler takes two parameters - a format string and an `HttpHandler` function.
 
-The format string supports the following format chars:
+The format string supports the following format chars, and now also supports **named parameters** using the syntax `%c:name` (e.g. `%i:petId`):
 
 | Format Char | Type |
 | ----------- | ---- |
@@ -1111,6 +1114,8 @@ The format string supports the following format chars:
 | `%f` | `float`/`double` |
 | `%O` | `Guid` (including short GUIDs*) |
 | `%u` | `uint64` (formatted as a short ID*) |
+
+**Named parameters**: You can use `%c:name` to assign a name to a route parameter, which is especially useful for OpenAPI/Swagger documentation and for clarity. For example, `routef "/pet/%i:petId"` will match `/pet/42` and bind `petId` to `42`.
 
 *) Please note that the `%O` and `%u` format characters also support URL friendly short GUIDs and IDs.
 

--- a/samples/EndpointRoutingApp/Program.fs
+++ b/samples/EndpointRoutingApp/Program.fs
@@ -19,8 +19,7 @@ let handler3 (a: string, b: string, c: string, d: int) : HttpHandler =
     fun (_: HttpFunc) (ctx: HttpContext) -> sprintf "Hello %s %s %s %i" a b c d |> ctx.WriteTextAsync
 
 let handlerNamed (petId: int) : HttpHandler =
-    fun (_: HttpFunc) (ctx: HttpContext) ->
-        sprintf "PetId: %i" petId |> ctx.WriteTextAsync
+    fun (_: HttpFunc) (ctx: HttpContext) -> sprintf "PetId: %i" petId |> ctx.WriteTextAsync
 
 let endpoints =
     [

--- a/samples/EndpointRoutingApp/Program.fs
+++ b/samples/EndpointRoutingApp/Program.fs
@@ -18,6 +18,10 @@ let handler2 (firstName: string, age: int) : HttpHandler =
 let handler3 (a: string, b: string, c: string, d: int) : HttpHandler =
     fun (_: HttpFunc) (ctx: HttpContext) -> sprintf "Hello %s %s %s %i" a b c d |> ctx.WriteTextAsync
 
+let handlerNamed (petId: int) : HttpHandler =
+    fun (_: HttpFunc) (ctx: HttpContext) ->
+        sprintf "PetId: %i" petId |> ctx.WriteTextAsync
+
 let endpoints =
     [
         subRoute "/foo" [ GET [ route "/bar" (text "Aloha!") ] ]
@@ -25,6 +29,7 @@ let endpoints =
             route "/" (text "Hello World")
             routef "/%s/%i" handler2
             routef "/%s/%s/%s/%i" handler3
+            routef "/pet/%i:petId" handlerNamed
         ]
         GET_HEAD [
             route "/foo" (text "Bar")

--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -23,6 +23,7 @@ module RouteTemplateBuilder =
 
     let private getConstraint (i: int) (c: char) (name: string option) =
         let name = Option.defaultValue (sprintf "%c%i" c i) name
+
         match c with
         | 'b' -> name, sprintf "{%s:bool}" name // bool
         | 'c' -> name, sprintf "{%s:length(1)}" name // char
@@ -44,14 +45,20 @@ module RouteTemplateBuilder =
                 match tail with
                 | ':' :: stail ->
                     let splitIndex = stail |> List.tryFindIndex (fun c -> c = '/')
+
                     match splitIndex with
                     | Some splitIndex ->
                         let name, newTail = stail |> List.splitAt splitIndex
-                        let placeholderName, placeholderTemplate = getConstraint i c (Some (System.String.Concat(Array.ofList(name))))
+
+                        let placeholderName, placeholderTemplate =
+                            getConstraint i c (Some(System.String.Concat(Array.ofList (name))))
+
                         let template, mappings = convert (i + 1) newTail
                         placeholderTemplate + template, (placeholderName, c) :: mappings
                     | None ->
-                        let placeholderName, placeholderTemplate = getConstraint i c (Some (System.String.Concat(Array.ofList(stail))))
+                        let placeholderName, placeholderTemplate =
+                            getConstraint i c (Some(System.String.Concat(Array.ofList (stail))))
+
                         let template, mappings = convert (i + 1) []
                         placeholderTemplate + template, (placeholderName, c) :: mappings
                 | _ ->

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -166,7 +166,11 @@ let ``routef: GET "/pet/%i:petId" returns named parameter`` (path: string, expec
         let endpoints: Endpoint list =
             [
                 GET [ routef "/pet/%i:petId" (fun (petId: int) -> text ($"PetId: {petId}")) ]
-                GET [ routef "/foo/%i/bar/%i:barId" (fun (fooId: int, barId: int) -> text ($"FooId: {fooId}, BarId: {barId}")) ]
+                GET [
+                    routef
+                        "/foo/%i/bar/%i:barId"
+                        (fun (fooId: int, barId: int) -> text ($"FooId: {fooId}, BarId: {barId}"))
+                ]
             ]
 
         let notFoundHandler = "Not Found" |> text |> RequestErrors.notFound
@@ -189,12 +193,16 @@ let ``routef: GET "/pet/%i:petId" returns named parameter`` (path: string, expec
 [<InlineData("/foo/999/bar/789", "FooId: 999, BarId: 789")>]
 [<InlineData("/foo/-1/bar/123", "FooId: -1, BarId: 123")>]
 [<InlineData("/foo/abc/bar/def", "Not Found")>]
-let ``routef: GET "/foo/%i:fooId/bar/%i/baz/%s:bazId" returns named and unnamed parameters`` (path: string, expected: string) =
+let ``routef: GET "/foo/%i:fooId/bar/%i/baz/%s:bazId" returns named and unnamed parameters``
+    (path: string, expected: string)
+    =
     task {
         let endpoints: Endpoint list =
             [
                 GET [
-                    routef "/foo/%i:fooId/bar/%s:barId" (fun (fooId: int, barId: string) -> text ($"FooId: {fooId}, BarId: {barId}"))
+                    routef
+                        "/foo/%i:fooId/bar/%s:barId"
+                        (fun (fooId: int, barId: string) -> text ($"FooId: {fooId}, BarId: {barId}"))
                 ]
             ]
 

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -158,9 +158,7 @@ let ``routef: GET "/pet/%i:petId" returns named parameter`` (path: string, expec
     task {
         let endpoints: Endpoint list =
             [
-                GET [
-                    routef "/pet/%i:petId" (fun (petId: int) -> text ($"PetId: {petId}"))
-                ]
+                GET [ routef "/pet/%i:petId" (fun (petId: int) -> text ($"PetId: {petId}")) ]
             ]
 
         let notFoundHandler = "Not Found" |> text |> RequestErrors.notFound

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -193,7 +193,7 @@ let ``routef: GET "/pet/%i:petId" returns named parameter`` (path: string, expec
 [<InlineData("/foo/999/bar/789", "FooId: 999, BarId: 789")>]
 [<InlineData("/foo/-1/bar/123", "FooId: -1, BarId: 123")>]
 [<InlineData("/foo/abc/bar/def", "Not Found")>]
-let ``routef: GET "/foo/%i:fooId/bar/%i/baz/%s:bazId" returns named and unnamed parameters``
+let ``routef: GET "/foo/%i:fooId/bar/%i" returns named and unnamed parameters``
     (path: string, expected: string)
     =
     task {


### PR DESCRIPTION
## Description

Add support for named parameters to `routef`. This allows you to use the syntax `%i:barcode` to name a parameter.

This will allow the Giraffe.OpenApi package to have named parameters instead of their names being simple `[type][index]` (e.g., "i0").

## How to test

1. Pull down the repo.
2. Run the EndpointRoutingApp sample app.
3. Navigate to `https://localhost:56830/pet/123`.
4. Should see text: "PetId: 123"

## Related issues

https://github.com/giraffe-fsharp/Giraffe/issues/611