### PR TITLE
Could we avoid allocation of UTF8 byte array?

### DIFF
--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -503,8 +503,7 @@ module Core =
     /// <param name="str">The string value to be send back to the client.</param>
     /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
     let setBodyFromString (str: string) : HttpHandler =
-        let bytes = Encoding.UTF8.GetBytes str
-        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteBytesAsync bytes
+        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteStringAsync str
 
     /// <summary>
     /// Writes an UTF-8 encoded string to the body of the HTTP response and sets the HTTP Content-Length header accordingly, as well as the Content-Type header to text/plain.


### PR DESCRIPTION
Could we avoid allocation of UTF8 byte array?

---

Another code-fixes to consider as well:
https://github.com/giraffe-fsharp/Giraffe/blob/c00ace4185277ba96f90b3cc617a434f75999161/src/Giraffe/Helpers.fs#L10
The RecyclableMemoryStreamManager could be constructed like this when called:

```fsharp
let internal recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>(fun () -> RecyclableMemoryStreamManager())
```
...and then it wouldn't be null ever.

---

I'm not sure if the portMap dictionary creation and filling should be inside or outside of the `fun next` here:
https://github.com/giraffe-fsharp/Giraffe/blob/c00ace4185277ba96f90b3cc617a434f75999161/src/Giraffe/Routing.fs#L54
...because now it constructs a new dictionary on each next-call. Will there be more next-calls than routePorts calls? Just to note that Dictionary is not thread-safe so not to put it outside `let routePorts`.
