### PR TITLE
Add PBT (property-based tests) for the Giraffe Routing with FsCheck, and update xUnit to v3

### DIFF
--- a/tests/Giraffe.Tests/Giraffe.Tests.fsproj
+++ b/tests/Giraffe.Tests/Giraffe.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="FormatExpressionTests.fs" />
     <Compile Include="HttpHandlerTests.fs" />
     <Compile Include="RoutingTests.fs" />
+    <Compile Include="RoutingTests.Props.fs" />
     <Compile Include="RequestLimitationTests.fs" />
     <Compile Include="ResponseCachingTests.fs" />
     <Compile Include="EndpointRoutingTests.fs" />
@@ -52,7 +53,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit" Version="2.9.*" />
+    <PackageReference Include="FsCheck" Version="3.3.3" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="3.3.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Giraffe.Tests/Helpers.fs
+++ b/tests/Giraffe.Tests/Helpers.fs
@@ -23,7 +23,7 @@ open Giraffe
 // Common functions
 // ---------------------------------
 
-let toTheoryData xs =
+let toTheoryData (xs: 'a seq) =
     let data = new TheoryData<_>()
 
     for x in xs do

--- a/tests/Giraffe.Tests/RoutingTests.Props.fs
+++ b/tests/Giraffe.Tests/RoutingTests.Props.fs
@@ -1,0 +1,205 @@
+module Giraffe.Tests.RoutingTestsProp
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Http
+open Xunit
+open NSubstitute
+open Giraffe
+open Giraffe.Tests
+open FsCheck.FSharp
+open FsCheck.Xunit
+
+module Utils =
+
+    type GiraffeGuid =
+        static member Guid() =
+            ArbMap.defaults |> ArbMap.arbitrary<Guid>
+
+    type GiraffeShortGuid =
+        static member ShortGuid() =
+            ArbMap.defaults
+            |> ArbMap.arbitrary<Guid>
+            |> Arb.convert Giraffe.ShortGuid.fromGuid Giraffe.ShortGuid.toGuid
+
+    type GiraffeShortId =
+        static member ShortId() =
+            ArbMap.defaults
+            |> ArbMap.arbitrary<uint64>
+            |> Arb.convert Giraffe.ShortId.fromUInt64 Giraffe.ShortId.toUInt64
+
+    type GiraffeFloat =
+        static member Float() =
+            ArbMap.defaults
+            |> ArbMap.arbitrary<float>
+            |> Arb.filter (fun x -> not (Double.IsNaN(x) || Double.IsInfinity(x)))
+
+    type GiraffeString =
+        static member String() =
+            ArbMap.defaults
+            |> ArbMap.arbitrary<string>
+            |> Arb.mapFilter _.Replace("/", "-") (String.IsNullOrWhiteSpace >> not)
+
+    type GiraffeChar =
+        static member Char() =
+            ArbMap.defaults |> ArbMap.arbitrary<char> |> Arb.filter ((<>) '/')
+
+    let app =
+        GET
+        >=> choose [
+            route "/" >=> text "Hello World"
+            routef "/is-valid/%b" (fun isValid -> text (sprintf "IsValid: %b" isValid))
+            routef "/char/%c" (fun char -> text (sprintf "Char: %c" char))
+            routef "/name/%s" (fun name -> text (sprintf "Name: %s" name))
+            routef "/age/%i" (fun age -> text (sprintf "Age: %i" age))
+            routef "/price/%f" (fun price -> text (sprintf "Price: %f" price))
+            routef "/guid/%O" (fun (guid: Guid) -> text (sprintf "GUID: %O" guid))
+            routef "/short-guid/%s" (fun shortGuid -> text (sprintf "Short GUID: %O" shortGuid))
+            routef "/short-id/%s" (fun shortId -> text (sprintf "Short ID: %O" shortId))
+            setStatusCode 404 >=> text "Not found"
+        ]
+
+[<Property>]
+let ``routef: GET "/is-valid/%b" works`` (x: bool) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/is-valid/%b" x))
+    |> ignore
+
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "IsValid: %b" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeChar> |])>]
+let ``routef: GET "/char/%c" works`` (x: char) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/char/%c" x)) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Char: %c" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeString> |])>]
+let ``routef: GET "/name/%s" works`` (x: string) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/name/%s" x)) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Name: %s" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property>]
+let ``routef: GET "/age/%i" works`` (x: int) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/age/%d" x)) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Age: %d" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeFloat> |])>]
+let ``routef: GET "/price/%f" works`` (x: float) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/price/%f" x)) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Price: %f" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+let ``routef: GET "/guid/%O" works`` (x: Guid) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/guid/%O" x)) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "GUID: %O" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeShortGuid> |])>]
+let ``routef: GET "/short-guid/%s" works`` (x: string) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/short-guid/%s" x))
+    |> ignore
+
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Short GUID: %s" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeShortId> |])>]
+let ``routef: GET "/short-id/%s" works`` (x: string) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/short-id/%s" x))
+    |> ignore
+
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Short ID: %s" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }

--- a/tests/Giraffe.Tests/RoutingTests.Props.fs
+++ b/tests/Giraffe.Tests/RoutingTests.Props.fs
@@ -12,10 +12,6 @@ open FsCheck.Xunit
 
 module Utils =
 
-    type GiraffeGuid =
-        static member Guid() =
-            ArbMap.defaults |> ArbMap.arbitrary<Guid>
-
     type GiraffeShortGuid =
         static member ShortGuid() =
             ArbMap.defaults
@@ -166,7 +162,7 @@ let ``routef: GET "/price/%f" works`` (x: float) =
         | Some ctx -> Assert.Equal(expected, getBody ctx)
     }
 
-[<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+[<Property>]
 let ``routef: GET "/guid/%O" works`` (x: Guid) =
     let ctx = Substitute.For<HttpContext>()
 
@@ -302,11 +298,11 @@ let ``routef: GET on an unmatched path always falls through to 404`` (suffix: st
 
 module ShortGuidProps =
 
-    [<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+    [<Property>]
     let ``ShortGuid: fromGuid >> toGuid roundtrips`` (guid: Guid) =
         guid |> ShortGuid.fromGuid |> ShortGuid.toGuid = guid
 
-    [<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+    [<Property>]
     let ``ShortGuid: fromGuid always produces a 22 character string`` (guid: Guid) =
         (ShortGuid.fromGuid guid).Length = 22
 

--- a/tests/Giraffe.Tests/RoutingTests.Props.fs
+++ b/tests/Giraffe.Tests/RoutingTests.Props.fs
@@ -20,13 +20,13 @@ module Utils =
         static member ShortGuid() =
             ArbMap.defaults
             |> ArbMap.arbitrary<Guid>
-            |> Arb.convert Giraffe.ShortGuid.fromGuid Giraffe.ShortGuid.toGuid
+            |> Arb.convert ShortGuid.fromGuid ShortGuid.toGuid
 
     type GiraffeShortId =
         static member ShortId() =
             ArbMap.defaults
             |> ArbMap.arbitrary<uint64>
-            |> Arb.convert Giraffe.ShortId.fromUInt64 Giraffe.ShortId.toUInt64
+            |> Arb.convert ShortId.fromUInt64 ShortId.toUInt64
 
     type GiraffeFloat =
         static member Float() =
@@ -48,16 +48,35 @@ module Utils =
         GET
         >=> choose [
             route "/" >=> text "Hello World"
+            routeCi "/hello-ci" >=> text "CI works"
             routef "/is-valid/%b" (fun isValid -> text (sprintf "IsValid: %b" isValid))
             routef "/char/%c" (fun char -> text (sprintf "Char: %c" char))
             routef "/name/%s" (fun name -> text (sprintf "Name: %s" name))
             routef "/age/%i" (fun age -> text (sprintf "Age: %i" age))
+            routef "/big-age/%d" (fun (age: int64) -> text (sprintf "BigAge: %d" age))
             routef "/price/%f" (fun price -> text (sprintf "Price: %f" price))
             routef "/guid/%O" (fun (guid: Guid) -> text (sprintf "GUID: %O" guid))
             routef "/short-guid/%s" (fun shortGuid -> text (sprintf "Short GUID: %O" shortGuid))
             routef "/short-id/%s" (fun shortId -> text (sprintf "Short ID: %O" shortId))
+            routef "/combo/%s/%i" (fun (name, age) -> text (sprintf "Combo: %s is %i" name age))
             setStatusCode 404 >=> text "Not found"
         ]
+
+    /// Re-cases every character of `s` according to `flags`, cycling through
+    /// `flags` when it is shorter than `s`. Used to exercise case-insensitive
+    /// route matching with arbitrary casing.
+    let toggleCase (flags: bool[]) (s: string) =
+        if flags.Length = 0 then
+            s
+        else
+            String.mapi
+                (fun i c ->
+                    if flags.[i % flags.Length] then
+                        Char.ToUpperInvariant c
+                    else
+                        Char.ToLowerInvariant c
+                )
+                s
 
 [<Property>]
 let ``routef: GET "/is-valid/%b" works`` (x: bool) =
@@ -203,3 +222,100 @@ let ``routef: GET "/short-id/%s" works`` (x: string) =
         | None -> assertFailf "Result was expected to be %s" expected
         | Some ctx -> Assert.Equal(expected, getBody ctx)
     }
+
+[<Property>]
+let ``routef: GET "/big-age/%d" works`` (x: int64) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/big-age/%d" x))
+    |> ignore
+
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "BigAge: %d" x
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeString> |])>]
+let ``routef: GET "/combo/%s/%i" works with multiple captured arguments`` (name: string, age: int) =
+    let ctx = Substitute.For<HttpContext>()
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+
+    ctx.Request.Path.ReturnsForAnyArgs(PathString(sprintf "/combo/%s/%i" name age))
+    |> ignore
+
+    ctx.Response.Body <- new MemoryStream()
+    let expected = sprintf "Combo: %s is %i" name age
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property>]
+let ``routeCi: GET "/hello-ci" works regardless of casing`` (flags: bool[]) =
+    let ctx = Substitute.For<HttpContext>()
+    let path = Utils.toggleCase flags "/hello-ci"
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString path) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "CI works"
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Property(Arbitrary = [| typeof<Utils.GiraffeString> |])>]
+let ``routef: GET on an unmatched path always falls through to 404`` (suffix: string) =
+    let ctx = Substitute.For<HttpContext>()
+    let path = sprintf "/does-not-exist/%s" suffix
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString path) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    task {
+        let! result = Utils.app next ctx
+
+        match result with
+        | None -> assertFail "Result was expected to be Some ctx with a 404 response"
+        | Some ctx ->
+            Assert.Equal(404, ctx.Response.StatusCode)
+            Assert.Equal("Not found", getBody ctx)
+    }
+
+module ShortGuidProps =
+
+    [<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+    let ``ShortGuid: fromGuid >> toGuid roundtrips`` (guid: Guid) =
+        guid |> ShortGuid.fromGuid |> ShortGuid.toGuid = guid
+
+    [<Property(Arbitrary = [| typeof<Utils.GiraffeGuid> |])>]
+    let ``ShortGuid: fromGuid always produces a 22 character string`` (guid: Guid) =
+        (ShortGuid.fromGuid guid).Length = 22
+
+module ShortIdProps =
+
+    [<Property>]
+    let ``ShortId: fromUInt64 >> toUInt64 roundtrips`` (id: uint64) =
+        id |> ShortId.fromUInt64 |> ShortId.toUInt64 = id
+
+    [<Property>]
+    let ``ShortId: fromUInt64 always produces an 11 character string`` (id: uint64) =
+        (ShortId.fromUInt64 id).Length = 11


### PR DESCRIPTION
## Description

With this PR, I'm adding a new module with the first property-based tests for the Giraffe Routing module with [FsCheck](https://github.com/fscheck/FsCheck), and I'm also updating xUnit to v3.

> [!NOTE]
> xUnit [Migrating Unit Tests from v2 to v3](https://xunit.net/docs/getting-started/v3/migration).

## How to test

Check CI output.

## Related issues

N/A