### PR TITLE
Add groups for F# analyzers in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      fsharp-analyzers-group:
+        patterns:
+          - "fsharp-analyzers"
+          - "Ionide.Analyzers"


### PR DESCRIPTION
## Description

Add fsharp-analyzers group to Dependabot configuration so both packages are updated together.

## How to test

N/A

## Related issues

N/A