### PR TITLE
feat: add QUERY method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Add first-class support for the HTTP `QUERY` method.
 - [feat: add routeBind support to Giraffe.EndpointRouting](https://github.com/giraffe-fsharp/Giraffe/pull/709) - Credits @AugustoRengel
 - [Add KeepAChangelog](https://github.com/giraffe-fsharp/Giraffe/pull/717) - Credits @64J0
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -753,6 +753,7 @@ Giraffe exposes a set of `HttpHandler` functions which can filter a request base
 - `POST`
 - `PUT`
 - `PATCH`
+- `QUERY`
 - `DELETE`
 - `HEAD`
 - `OPTIONS`
@@ -1853,7 +1854,7 @@ If you prefer this API you can either copy paste [Aleksander](https://github.com
 
 #### Binding Models (catch all)
 
-The `BindModelAsync<'T> (?cultureInfo : CultureInfo)` method is a generic model binding function which will try to pick the right model parsing function based on a request's HTTP verb and `Content-Type` header. With the help of `BindModelAsync<'T>` it is possible to create a single endpoint which can bind JSON, XML, form and query string data:
+The `BindModelAsync<'T> (?cultureInfo : CultureInfo)` method is a generic model binding function which will try to pick the right model parsing function based on a request's HTTP verb and `Content-Type` header. The `QUERY` method is treated as a body-bearing method alongside `POST`, `PUT`, `PATCH` and `DELETE`. With the help of `BindModelAsync<'T>` it is possible to create a single endpoint which can bind JSON, XML, form and query string data:
 
 ```fsharp
 [<CLIMutable>]
@@ -3597,7 +3598,7 @@ The `MapGiraffeEndpoints` extension method translates those functions into the f
 
 The following routing functions are available as part of the `Giraffe.EndpointRouting` module:
 
-- `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`, `CONNECT`
+- `GET`, `POST`, `PUT`, `PATCH`, `QUERY`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`, `CONNECT`
 - `route`
 - `routeWithExtensions`
 - `routef`

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -165,6 +165,10 @@ module Core =
     let POST: HttpHandler = httpVerb HttpMethods.IsPost
     let PUT: HttpHandler = httpVerb HttpMethods.IsPut
     let PATCH: HttpHandler = httpVerb HttpMethods.IsPatch
+
+    let QUERY: HttpHandler =
+        httpVerb (fun method -> method.Equals("QUERY", StringComparison.OrdinalIgnoreCase))
+
     let DELETE: HttpHandler = httpVerb HttpMethods.IsDelete
     let HEAD: HttpHandler = httpVerb HttpMethods.IsHead
     let OPTIONS: HttpHandler = httpVerb HttpMethods.IsOptions

--- a/src/Giraffe/EndpointRouting.fs
+++ b/src/Giraffe/EndpointRouting.fs
@@ -158,6 +158,7 @@ module Routers =
         | POST
         | PUT
         | PATCH
+        | QUERY
         | DELETE
         | HEAD
         | OPTIONS
@@ -171,6 +172,7 @@ module Routers =
             | POST -> "POST"
             | PUT -> "PUT"
             | PATCH -> "PATCH"
+            | QUERY -> "QUERY"
             | DELETE -> "DELETE"
             | HEAD -> "HEAD"
             | OPTIONS -> "OPTIONS"
@@ -248,6 +250,7 @@ module Routers =
     let POST = applyHttpVerbToEndpoints POST
     let PUT = applyHttpVerbToEndpoints PUT
     let PATCH = applyHttpVerbToEndpoints PATCH
+    let QUERY = applyHttpVerbToEndpoints QUERY
     let DELETE = applyHttpVerbToEndpoints DELETE
     let HEAD = applyHttpVerbToEndpoints HEAD
     let OPTIONS = applyHttpVerbToEndpoints OPTIONS

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -352,6 +352,7 @@ type HttpContextExtensions() =
                 method.Equals "POST"
                 || method.Equals "PUT"
                 || method.Equals "PATCH"
+                || method.Equals "QUERY"
                 || method.Equals "DELETE"
             then
                 let original = StringSegment(ctx.Request.ContentType)

--- a/tests/Giraffe.Tests/EndpointRoutingTests.fs
+++ b/tests/Giraffe.Tests/EndpointRoutingTests.fs
@@ -85,6 +85,28 @@ let ``routeWithExtensions: GET request returns expected result`` (path: string, 
         content |> shouldEqual expected
     }
 
+[<Fact>]
+let ``route: QUERY request returns expected result`` () =
+    let endpoints: Endpoint list = [ QUERY [ route "/query" (text "query") ] ]
+
+    let notFoundHandler = "Not Found" |> text |> RequestErrors.notFound
+
+    let configureApp (app: IApplicationBuilder) =
+        app.UseRouting().UseGiraffe(endpoints).UseGiraffe(notFoundHandler)
+
+    let configureServices (services: IServiceCollection) =
+        services.AddRouting().AddGiraffe() |> ignore
+
+    task {
+        let request = createRequest (HttpMethod("QUERY")) "/query"
+
+        let! response = makeRequest (fun () -> configureApp) configureServices () request
+
+        let! content = response |> readText
+
+        content |> shouldEqual "query"
+    }
+
 [<Theory>]
 [<InlineData("/empty/5", "/empty i = 5")>]
 [<InlineData("/normal/10", "/normal i = 10")>]

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -393,6 +393,29 @@ let ``POST "/post/2" returns "2"`` () =
     }
 
 [<Fact>]
+let ``QUERY "/query" returns "query"`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let app =
+        choose [
+            QUERY >=> route "/query" >=> text "query"
+            setStatusCode 404 >=> text "Not found"
+        ]
+
+    ctx.Request.Method.ReturnsForAnyArgs "QUERY" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/query")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "query"
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
 let ``PUT "/post/2" returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
 

--- a/tests/Giraffe.Tests/ModelBindingTests.fs
+++ b/tests/Giraffe.Tests/ModelBindingTests.fs
@@ -1274,6 +1274,46 @@ let ``BindModelAsync with JSON content returns correct result`` () =
     }
 
 [<Fact>]
+let ``BindModelAsync with QUERY JSON content returns correct result`` () =
+    let ctx = Substitute.For<HttpContext>()
+    mockJson ctx
+
+    let outputCustomer (c: Customer) = text (c.ToString())
+    let app = route "/auto" >=> bindModel<Customer> None outputCustomer
+
+    let contentType = "application/json"
+
+    let queryContent =
+        "{ \"name\": \"John Doe\", \"isVip\": true, \"birthDate\": \"1990-04-20\", \"balance\": 150000.5, \"loyaltyPoints\": 137 }"
+
+    let stream = new MemoryStream()
+    let writer = new StreamWriter(stream, Encoding.UTF8)
+    writer.Write queryContent
+    writer.Flush()
+    stream.Position <- 0L
+
+    let headers = HeaderDictionary()
+    headers.Add("Content-Type", StringValues(contentType))
+    headers.Add("Content-Length", StringValues(stream.Length.ToString()))
+    ctx.Request.ContentType.ReturnsForAnyArgs contentType |> ignore
+    ctx.Request.Method.ReturnsForAnyArgs "QUERY" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/auto")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    ctx.Request.Body <- stream
+
+    let expected =
+        "Name: John Doe, IsVip: true, BirthDate: 1990-04-20, Balance: 150000.50, LoyaltyPoints: 137"
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
 let ``BindModelAsync with XML content returns correct result`` () =
     let ctx = Substitute.For<HttpContext>()
     mockXml ctx


### PR DESCRIPTION
## Summary
- add first-class HTTP QUERY support for classic Giraffe handlers
- add QUERY endpoint routing support
- treat QUERY as a body-bearing method for BindModelAsync and cover it with tests
- add a changelog entry

Closes #739.

## Verification
- PATH="$HOME/.local/opt/dotnet:$PATH" DOTNET_ROOT="$HOME/.local/opt/dotnet" dotnet fantomas --check src samples tests
- PATH="$HOME/.local/opt/dotnet:$PATH" DOTNET_ROOT="$HOME/.local/opt/dotnet" dotnet build src/Giraffe/Giraffe.fsproj --no-restore
- PATH="$HOME/.local/opt/dotnet:$PATH" DOTNET_ROOT="$HOME/.local/opt/dotnet" dotnet test tests/Giraffe.Tests/Giraffe.Tests.fsproj -f net8.0 --no-restore
- PATH="$HOME/.local/opt/dotnet:$PATH" DOTNET_ROOT="$HOME/.local/opt/dotnet" dotnet test tests/Giraffe.Tests/Giraffe.Tests.fsproj -f net9.0 --no-restore
- PATH="$HOME/.local/opt/dotnet:$PATH" DOTNET_ROOT="$HOME/.local/opt/dotnet" dotnet test tests/Giraffe.Tests/Giraffe.Tests.fsproj -f net10.0 --no-restore