### PR TITLE
Add a new function that writes a Markdown response

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2667,6 +2667,65 @@ let someHandler : HttpHandler =
     htmlView indexView
 ```
 
+#### Writing Markdown
+
+The `WriteMarkdownStringAsync (markdown : string)` extension method and the `markdownString (markdown : string)` http handler are both equivalent to [writing strings](#writing-strings) except that they will also set the `Content-Type` header to `text/markdown`, using the official [`System.Net.Mime.MediaTypeNames.Text.Markdown`](https://learn.microsoft.com/en-us/dotnet/api/system.net.mime.mediatypenames.text.markdown) constant (available from .NET 8 onwards; earlier target frameworks fall back to the equivalent `"text/markdown"` literal):
+
+```fsharp
+let someHandler (dataObj : obj) : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
+            // Do stuff
+            return! ctx.WriteMarkdownStringAsync "# Giraffe\n\nA *functional* web framework."
+        }
+
+// or...
+
+let someHandler (dataObj : obj) : HttpHandler =
+    // Do stuff
+    markdownString "# Giraffe\n\nA *functional* web framework."
+```
+
+A request to a route configured with the handler above will receive:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: text/markdown; charset=utf-8
+Content-Length: 40
+
+# Giraffe
+
+A *functional* web framework.
+```
+
+Like every other Giraffe response writer, `markdownString` is just an `HttpHandler` and can be composed with other handlers via the [`>=>`](#compose-) (fish) operator, for example to set the status code and an additional response header before writing the body:
+
+```fsharp
+let readmeHandler : HttpHandler =
+    setStatusCode 200
+    >=> setHttpHeader "Cache-Control" "public, max-age=3600"
+    >=> markdownString "# Giraffe\n\nA *functional* web framework."
+
+let webApp =
+    choose [
+        route "/"       >=> text "Hello World"
+        route "/readme" >=> readmeHandler
+    ]
+```
+
+A request to `/readme` will receive:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: text/markdown; charset=utf-8
+Cache-Control: public, max-age=3600
+Content-Length: 40
+
+# Giraffe
+
+A *functional* web framework.
+```
+
 ### Content Negotiation
 
 Giraffe's default [response writers](#response-writing) will always send a response in a specific media type regardless of a client's own requirements. Content negotiation on the other hand allows a Giraffe web server to examine a web request's `Accept` HTTP header and decide an appropriate data representation on the fly.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2669,21 +2669,21 @@ let someHandler : HttpHandler =
 
 #### Writing Markdown
 
-The `WriteMarkdownStringAsync (markdown : string)` extension method and the `markdownString (markdown : string)` http handler are both equivalent to [writing strings](#writing-strings) except that they will also set the `Content-Type` header to `text/markdown`, using the official [`System.Net.Mime.MediaTypeNames.Text.Markdown`](https://learn.microsoft.com/en-us/dotnet/api/system.net.mime.mediatypenames.text.markdown) constant (available from .NET 8 onwards; earlier target frameworks fall back to the equivalent `"text/markdown"` literal):
+The `WriteMarkdownAsync (markdown : string)` extension method and the `markdown (markdown : string)` http handler are both equivalent to [writing strings](#writing-strings) except that they will also set the `Content-Type` header to `text/markdown`, using the official [`System.Net.Mime.MediaTypeNames.Text.Markdown`](https://learn.microsoft.com/en-us/dotnet/api/system.net.mime.mediatypenames.text.markdown) constant (available from .NET 8 onwards; earlier target frameworks fall back to the equivalent `"text/markdown"` literal):
 
 ```fsharp
 let someHandler (dataObj : obj) : HttpHandler =
     fun (next : HttpFunc) (ctx : HttpContext) ->
         task {
             // Do stuff
-            return! ctx.WriteMarkdownStringAsync "# Giraffe\n\nA *functional* web framework."
+            return! ctx.WriteMarkdownAsync "# Giraffe\n\nA *functional* web framework."
         }
 
 // or...
 
 let someHandler (dataObj : obj) : HttpHandler =
     // Do stuff
-    markdownString "# Giraffe\n\nA *functional* web framework."
+    markdown "# Giraffe\n\nA *functional* web framework."
 ```
 
 A request to a route configured with the handler above will receive:
@@ -2698,13 +2698,13 @@ Content-Length: 40
 A *functional* web framework.
 ```
 
-Like every other Giraffe response writer, `markdownString` is just an `HttpHandler` and can be composed with other handlers via the [`>=>`](#compose-) (fish) operator, for example to set the status code and an additional response header before writing the body:
+Like every other Giraffe response writer, `markdown` is just an `HttpHandler` and can be composed with other handlers via the [`>=>`](#compose-) (fish) operator, for example to set the status code and an additional response header before writing the body:
 
 ```fsharp
 let readmeHandler : HttpHandler =
     setStatusCode 200
     >=> setHttpHeader "Cache-Control" "public, max-age=3600"
-    >=> markdownString "# Giraffe\n\nA *functional* web framework."
+    >=> markdown "# Giraffe\n\nA *functional* web framework."
 
 let webApp =
     choose [

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -583,7 +583,7 @@ module Core =
     /// </summary>
     /// <param name="markdown">The Markdown string to be sent back to the client.</param>
     /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
-    let markdownString (markdown: string) : HttpHandler =
+    let markdown (markdown: string) : HttpHandler =
         let bytes = Encoding.UTF8.GetBytes markdown
 
 #if NET8_0_OR_GREATER

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -578,6 +578,25 @@ module Core =
             ctx.WriteBytesAsync bytes
 
     /// <summary>
+    /// Writes a Markdown string to the body of the HTTP response.
+    /// It also sets the HTTP header Content-Type to text/markdown and sets the Content-Length header accordingly.
+    /// </summary>
+    /// <param name="markdown">The Markdown string to be send back to the client.</param>
+    /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
+    let markdownString (markdown: string) : HttpHandler =
+        let bytes = Encoding.UTF8.GetBytes markdown
+
+#if NET8_0_OR_GREATER
+        let contentType = System.Net.Mime.MediaTypeNames.Text.Markdown + "; charset=utf-8"
+#else
+        let contentType = "text/markdown; charset=utf-8"
+#endif
+
+        fun (_: HttpFunc) (ctx: HttpContext) ->
+            ctx.SetContentType contentType
+            ctx.WriteBytesAsync bytes
+
+    /// <summary>
     /// <para>Compiles a `Giraffe.GiraffeViewEngine.XmlNode` object to a HTML view and writes the output to the body of the HTTP response.</para>
     /// <para>It also sets the HTTP header `Content-Type` to `text/html` and sets the `Content-Length` header accordingly.</para>
     /// </summary>

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -581,7 +581,7 @@ module Core =
     /// Writes a Markdown string to the body of the HTTP response.
     /// It also sets the HTTP header Content-Type to text/markdown and sets the Content-Length header accordingly.
     /// </summary>
-    /// <param name="markdown">The Markdown string to be send back to the client.</param>
+    /// <param name="markdown">The Markdown string to be sent back to the client.</param>
     /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
     let markdownString (markdown: string) : HttpHandler =
         let bytes = Encoding.UTF8.GetBytes markdown

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -518,7 +518,7 @@ type HttpContextExtensions() =
     /// <param name="markdown">The Markdown string to be sent back to the client.</param>
     /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
     [<Extension>]
-    static member WriteMarkdownStringAsync(ctx: HttpContext, markdown: string) =
+    static member WriteMarkdownAsync(ctx: HttpContext, markdown: string) =
 #if NET8_0_OR_GREATER
         ctx.SetContentType(System.Net.Mime.MediaTypeNames.Text.Markdown + "; charset=utf-8")
 #else

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -511,6 +511,22 @@ type HttpContextExtensions() =
         ctx.WriteStringAsync html
 
     /// <summary>
+    /// Writes a Markdown string to the body of the HTTP response.
+    /// It also sets the HTTP header Content-Type to text/markdown and sets the Content-Length header accordingly.
+    /// </summary>
+    /// <param name="ctx">The current http context object.</param>
+    /// <param name="markdown">The Markdown string to be send back to the client.</param>
+    /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
+    [<Extension>]
+    static member WriteMarkdownStringAsync(ctx: HttpContext, markdown: string) =
+#if NET8_0_OR_GREATER
+        ctx.SetContentType(System.Net.Mime.MediaTypeNames.Text.Markdown + "; charset=utf-8")
+#else
+        ctx.SetContentType "text/markdown; charset=utf-8"
+#endif
+        ctx.WriteStringAsync markdown
+
+    /// <summary>
     /// <para>Compiles a `Giraffe.GiraffeViewEngine.XmlNode` object to a HTML view and writes the output to the body of the HTTP response.</para>
     /// <para>It also sets the HTTP header `Content-Type` to `text/html` and sets the `Content-Length` header accordingly.</para>
     /// </summary>

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -515,7 +515,7 @@ type HttpContextExtensions() =
     /// It also sets the HTTP header Content-Type to text/markdown and sets the Content-Length header accordingly.
     /// </summary>
     /// <param name="ctx">The current http context object.</param>
-    /// <param name="markdown">The Markdown string to be send back to the client.</param>
+    /// <param name="markdown">The Markdown string to be sent back to the client.</param>
     /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
     [<Extension>]
     static member WriteMarkdownStringAsync(ctx: HttpContext, markdown: string) =

--- a/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
+++ b/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
@@ -177,6 +177,54 @@ let ``WriteTextAsync with HTTP HEAD should not return text in body`` () =
     }
 
 [<Fact>]
+let ``WriteMarkdownStringAsync with HTTP GET should return markdown in body`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownStringAsync "# Hello World Giraffe"
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "# Hello World Giraffe"
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            Assert.Equal(expected, getBody ctx)
+            Assert.Equal("text/markdown; charset=utf-8", ctx.Response.Headers["Content-Type"].ToString())
+    }
+
+[<Fact>]
+let ``WriteMarkdownStringAsync with HTTP HEAD should not return markdown in body`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let testHandler =
+        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownStringAsync "# Hello World Giraffe"
+
+    let app = route "/" >=> testHandler
+
+    ctx.Request.Method.ReturnsForAnyArgs "HEAD" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = ""
+
+    task {
+        let! result = app (Some >> Task.FromResult) ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx -> Assert.Equal(expected, getBody ctx)
+    }
+
+[<Fact>]
 let ``WriteBytesAsync should not return Content-Length in header on 100`` () =
     let ctx = Substitute.For<HttpContext>()
 

--- a/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
+++ b/tests/Giraffe.Tests/HttpContextExtensionsTests.fs
@@ -177,11 +177,11 @@ let ``WriteTextAsync with HTTP HEAD should not return text in body`` () =
     }
 
 [<Fact>]
-let ``WriteMarkdownStringAsync with HTTP GET should return markdown in body`` () =
+let ``WriteMarkdownAsync with HTTP GET should return markdown in body`` () =
     let ctx = Substitute.For<HttpContext>()
 
     let testHandler =
-        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownStringAsync "# Hello World Giraffe"
+        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownAsync "# Hello World Giraffe"
 
     let app = route "/" >=> testHandler
 
@@ -202,11 +202,11 @@ let ``WriteMarkdownStringAsync with HTTP GET should return markdown in body`` ()
     }
 
 [<Fact>]
-let ``WriteMarkdownStringAsync with HTTP HEAD should not return markdown in body`` () =
+let ``WriteMarkdownAsync with HTTP HEAD should not return markdown in body`` () =
     let ctx = Substitute.For<HttpContext>()
 
     let testHandler =
-        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownStringAsync "# Hello World Giraffe"
+        fun (_: HttpFunc) (ctx: HttpContext) -> ctx.WriteMarkdownAsync "# Hello World Giraffe"
 
     let app = route "/" >=> testHandler
 

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -713,6 +713,66 @@ let ``GET "/person" returns rendered HTML view`` () =
     }
 
 [<Fact>]
+let ``GET "/readme" returns rendered Markdown string`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let app =
+        GET
+        >=> choose [
+            route "/" >=> text "Hello World"
+            route "/readme" >=> markdownString "# Giraffe\n\nA *functional* web framework."
+        ]
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/readme")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "# Giraffe\n\nA *functional* web framework."
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal("text/markdown; charset=utf-8", ctx.Response |> getContentType)
+    }
+
+[<Fact>]
+let ``GET "/readme" composed with setStatusCode and setHttpHeader returns Markdown string`` () =
+    let ctx = Substitute.For<HttpContext>()
+
+    let readmeHandler: HttpHandler =
+        setStatusCode 200
+        >=> setHttpHeader "Cache-Control" "public, max-age=3600"
+        >=> markdownString "# Giraffe\n\nA *functional* web framework."
+
+    let app =
+        GET
+        >=> choose [ route "/" >=> text "Hello World"; route "/readme" >=> readmeHandler ]
+
+    ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs(PathString("/readme")) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+
+    let expected = "# Giraffe\n\nA *functional* web framework."
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFailf "Result was expected to be %s" expected
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal(200, ctx.Response.StatusCode)
+            Assert.Equal("text/markdown; charset=utf-8", ctx.Response |> getContentType)
+            Assert.Equal("public, max-age=3600", ctx.Response.Headers["Cache-Control"].ToString())
+    }
+
+[<Fact>]
 let ``Warbler function should execute inner function each time`` () =
     let ctx = Substitute.For<HttpContext>()
     let inner () = Guid.NewGuid().ToString()

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -720,7 +720,7 @@ let ``GET "/readme" returns rendered Markdown string`` () =
         GET
         >=> choose [
             route "/" >=> text "Hello World"
-            route "/readme" >=> markdownString "# Giraffe\n\nA *functional* web framework."
+            route "/readme" >=> markdown "# Giraffe\n\nA *functional* web framework."
         ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -747,7 +747,7 @@ let ``GET "/readme" composed with setStatusCode and setHttpHeader returns Markdo
     let readmeHandler: HttpHandler =
         setStatusCode 200
         >=> setHttpHeader "Cache-Control" "public, max-age=3600"
-        >=> markdownString "# Giraffe\n\nA *functional* web framework."
+        >=> markdown "# Giraffe\n\nA *functional* web framework."
 
     let app =
         GET


### PR DESCRIPTION
## Description

With this PR I'm adding a new function that writes a Markdown response using the appropriate "content-type" value. I'm also adding new automated tests to cover this new function, and updating the DOCUMENTATION.

## How to test

Check CI.

## Related issues

N/A